### PR TITLE
Fix packaging rules for dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 node_modules
-dist
 coverage
 .git
 .gitignore


### PR DESCRIPTION
## Summary
- remove `dist` from `.npmignore` so compiled files are published

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68516b8ac094832ea1ad171a4bbfa83d