### PR TITLE
Regenerate lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-mini-form",
-  "version": "1.0.0",
+  "name": "react-minimalist-form",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-mini-form",
-      "version": "1.0.0",
+      "name": "react-minimalist-form",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- regenerate `package-lock.json` to match package name and version

## Testing
- `npm install --package-lock-only --ignore-scripts` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_b_68516e89a80c832e92cd9480cf7391c3