### PR TITLE
Add validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Designed to provide a simple and intuitive API for common form needs, including 
 
 🪶 Lightweight: No unnecessary overhead, just what you need for managing form state in React.
 
+❌ Optional Validation: Define validation rules and control error state when needed.
+
 ## Installation
 
 Install the library using `pnpm` (recommended) or your preferred package manager.
@@ -44,31 +46,41 @@ interface FormData {
 }
 
 const MyForm = () => {
-  const { values, handleChange, resetForm } = useForm<FormData>({
-    username: "",
-    email: "",
-  });
+  const { values, errors, handleChange, resetForm, validate } = useForm<FormData>(
+    {
+      username: "",
+      email: "",
+    },
+    {
+      username: (v) => (!v ? "Username is required" : null),
+      email: (v) => (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? null : "Invalid email"),
+    }
+  );
+
+  const onSubmit = () => {
+    if (validate()) {
+      console.log("submit", values);
+    }
+  };
 
   return (
-    <form>
+    <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }}>
       <input
         name='username'
         value={values.username}
         onChange={handleChange}
         placeholder='Username'
       />
+      {errors.username && <span>{errors.username}</span>}
       <input
         name='email'
         value={values.email}
         onChange={handleChange}
         placeholder='Email'
       />
-      <button
-        type='button'
-        onClick={resetForm}
-      >
-        Reset
-      </button>
+      {errors.email && <span>{errors.email}</span>}
+      <button type='submit'>Submit</button>
+      <button type='button' onClick={resetForm}>Reset</button>
     </form>
   );
 };
@@ -157,13 +169,14 @@ export default App;
 
 ## API
 
-`useForm<T>(initialValues: T): UseForm<T>`
+`useForm<T>(initialValues: T, validationRules?: ValidationRules<T>): UseForm<T>`
 
 A custom hook that provides utilities for managing form state.
 
 #### Parameters
 
 - `initialValues`: An object representing the initial state of your form. The shape of this object defines the structure of the form.
+- `validationRules` *(optional)*: An object with validation functions for each field.
 
 #### Returns
 
@@ -172,14 +185,26 @@ A custom hook that provides utilities for managing form state.
 - `handleChange`: A function to handle onChange events for input fields.
 - `resetForm`: Resets the form to its initial values.
 - `watch`: A function to track specific fields or the entire form state in real-time.
+- `errors`: Object containing validation errors.
+- `validate`: Run validation and update the errors state. Returns `true` when the form is valid.
 
 ### Example
 
 ```tsx
-const { values, setters, handleChange, resetForm, watch } = useForm({
-  username: "",
-  email: "",
-});
+const {
+  values,
+  errors,
+  setters,
+  handleChange,
+  resetForm,
+  validate,
+  watch,
+} = useForm(
+  { username: "", email: "" },
+  {
+    username: (v) => (!v ? "Required" : null),
+  }
+);
 ```
 
 ## Contributing

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -2,8 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useForm = void 0;
 const react_1 = require("react");
-const useForm = (initialValues) => {
+const useForm = (initialValues, validationRules) => {
     const [values, setValues] = (0, react_1.useState)(initialValues);
+    const [errors, setErrors] = (0, react_1.useState)({});
     const setters = Object.keys(initialValues).reduce((acc, key) => {
         acc[key] = (value) => {
             setValues((prevValues) => (Object.assign(Object.assign({}, prevValues), { [key]: value })));
@@ -19,15 +20,35 @@ const useForm = (initialValues) => {
     };
     const resetForm = () => {
         setValues(initialValues);
+        setErrors({});
     };
+    const validate = (0, react_1.useCallback)(() => {
+        if (!validationRules) {
+            return true;
+        }
+        const newErrors = {};
+        Object.keys(validationRules).forEach((key) => {
+            const rule = validationRules[key];
+            if (rule) {
+                const error = rule(values[key], values);
+                if (error) {
+                    newErrors[key] = error;
+                }
+            }
+        });
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    }, [validationRules, values]);
     const watch = (0, react_1.useCallback)((key) => {
         return key ? values[key] : values;
     }, [values]);
     return {
         values,
         setters,
+        errors,
         handleChange,
         resetForm,
+        validate,
         watch,
     };
 };

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
-export const useForm = (initialValues) => {
+export const useForm = (initialValues, validationRules) => {
     const [values, setValues] = useState(initialValues);
+    const [errors, setErrors] = useState({});
     const setters = Object.keys(initialValues).reduce((acc, key) => {
         acc[key] = (value) => {
             setValues((prevValues) => (Object.assign(Object.assign({}, prevValues), { [key]: value })));
@@ -16,15 +17,35 @@ export const useForm = (initialValues) => {
     };
     const resetForm = () => {
         setValues(initialValues);
+        setErrors({});
     };
+    const validate = useCallback(() => {
+        if (!validationRules) {
+            return true;
+        }
+        const newErrors = {};
+        Object.keys(validationRules).forEach((key) => {
+            const rule = validationRules[key];
+            if (rule) {
+                const error = rule(values[key], values);
+                if (error) {
+                    newErrors[key] = error;
+                }
+            }
+        });
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    }, [validationRules, values]);
     const watch = useCallback((key) => {
         return key ? values[key] : values;
     }, [values]);
     return {
         values,
         setters,
+        errors,
         handleChange,
         resetForm,
+        validate,
         watch,
     };
 };

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -1,12 +1,18 @@
 type Setters<T> = {
     [K in keyof T]: (value: T[K]) => void;
 };
+export type ValidationRules<T> = {
+    [K in keyof T]?: (value: T[K], values: T) => string | null;
+};
+type Errors<T> = Partial<Record<keyof T, string>>;
 interface UseForm<T> {
     values: T;
     setters: Setters<T>;
+    errors: Errors<T>;
     handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     resetForm: () => void;
+    validate: () => boolean;
     watch: <K extends keyof T>(key?: K) => T[K] | T;
 }
-export declare const useForm: <T extends Record<string, any>>(initialValues: T) => UseForm<T>;
+export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>) => UseForm<T>;
 export {};

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -8,22 +8,32 @@ type Setters<T> = {
   [K in keyof T]: (value: T[K]) => void;
 };
 
+export type ValidationRules<T> = {
+  [K in keyof T]?: (value: T[K], values: T) => string | null;
+};
+
+type Errors<T> = Partial<Record<keyof T, string>>;
+
 interface UseForm<T> {
   values: T;
   setters: Setters<T>;
+  errors: Errors<T>;
   handleChange: (
     e: React.ChangeEvent<
       HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
     >
   ) => void;
   resetForm: () => void;
+  validate: () => boolean;
   watch: <K extends keyof T>(key?: K) => T[K] | T;
 }
 
 export const useForm = <T extends Record<string, any>>(
-  initialValues: T
+  initialValues: T,
+  validationRules?: ValidationRules<T>
 ): UseForm<T> => {
   const [values, setValues] = useState<FormValues<T>>(initialValues);
+  const [errors, setErrors] = useState<Errors<T>>({});
 
   const setters = Object.keys(initialValues).reduce((acc, key) => {
     acc[key as keyof T] = (value: any) => {
@@ -51,7 +61,29 @@ export const useForm = <T extends Record<string, any>>(
 
   const resetForm = () => {
     setValues(initialValues);
+    setErrors({});
   };
+
+  const validate = useCallback((): boolean => {
+    if (!validationRules) {
+      return true;
+    }
+
+    const newErrors: Errors<T> = {};
+
+    Object.keys(validationRules).forEach((key) => {
+      const rule = validationRules[key as keyof T];
+      if (rule) {
+        const error = rule(values[key as keyof T], values);
+        if (error) {
+          newErrors[key as keyof T] = error;
+        }
+      }
+    });
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [validationRules, values]);
 
   const watch = useCallback(
     <K extends keyof T>(key?: K): T[K] | T => {
@@ -63,8 +95,10 @@ export const useForm = <T extends Record<string, any>>(
   return {
     values,
     setters,
+    errors,
     handleChange,
     resetForm,
+    validate,
     watch,
   };
 };


### PR DESCRIPTION
## Summary
- support optional validation rules and expose errors
- reset errors with `resetForm`
- document new validation API and example usage

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851704c314c832eb84fa06398156522