### PR TITLE
Implement dirty field tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Designed to provide a simple and intuitive API for common form needs, including 
 
 👀 Watch Functionality: Track individual fields or the entire form state in real-time.
 
+📝 Dirty State Tracking: `dirtyFields` and `isDirty` indicate modified fields and overall form changes.
+
 🔄 Reset Support: Easily reset form values to their initial state.
 
 🪶 Lightweight: No unnecessary overhead, just what you need for managing form state in React.
@@ -50,7 +52,7 @@ interface FormData {
 }
 
 const MyForm = () => {
-  const { values, errors, handleChange, resetForm, validate } = useForm<FormData>(
+  const { values, errors, dirtyFields, isDirty, handleChange, resetForm, validate } = useForm<FormData>(
     {
       username: "",
       email: "",
@@ -89,6 +91,8 @@ const MyForm = () => {
   );
 };
 ```
+
+`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. Calling `resetForm` clears both states.
 
 ## Advanced Example with Watch
 
@@ -255,6 +259,8 @@ A custom hook that provides utilities for managing form state.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `errors`: Object containing validation errors.
 - `validate`: Run validation and update the errors state. Returns `true` when the form is valid.
+- `dirtyFields`: Object tracking which fields have been modified.
+- `isDirty`: `true` when any field has changed.
 
 ### Example
 
@@ -263,6 +269,8 @@ const {
   values,
   errors,
   setters,
+  dirtyFields,
+  isDirty,
   handleChange,
   resetForm,
   validate,

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -5,9 +5,19 @@ const react_1 = require("react");
 const useForm = (initialValues, validationRules) => {
     const [values, setValues] = (0, react_1.useState)(initialValues);
     const [errors, setErrors] = (0, react_1.useState)({});
+    const initialDirty = Object.keys(initialValues).reduce((acc, key) => {
+        acc[key] = false;
+        return acc;
+    }, {});
+    const [dirtyFields, setDirtyFields] = (0, react_1.useState)(initialDirty);
+    const isDirty = Object.keys(initialValues).some((k) => dirtyFields[k]);
     const setters = Object.keys(initialValues).reduce((acc, key) => {
         acc[key] = (value) => {
-            setValues((prevValues) => (Object.assign(Object.assign({}, prevValues), { [key]: value })));
+            setValues((prevValues) => {
+                const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
+                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialValues[key] })));
+                return newValues;
+            });
         };
         return acc;
     }, {});
@@ -16,11 +26,34 @@ const useForm = (initialValues, validationRules) => {
         const newValue = type === "checkbox" && e.target instanceof HTMLInputElement
             ? e.target.checked
             : value;
-        setValues((prevValues) => (Object.assign(Object.assign({}, prevValues), { [name]: newValue })));
+        setValues((prevValues) => {
+            const path = name
+                .replace(/\[(\w+)\]/g, ".$1")
+                .split(".")
+                .filter(Boolean)
+                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const setNestedValue = (obj, keys, val) => {
+                var _a, _b;
+                if (!keys.length)
+                    return val;
+                const [first, ...rest] = keys;
+                if (Array.isArray(obj)) {
+                    const arr = [...obj];
+                    arr[first] = setNestedValue((_a = arr[first]) !== null && _a !== void 0 ? _a : (typeof rest[0] === "number" ? [] : {}), rest, val);
+                    return arr;
+                }
+                return Object.assign(Object.assign({}, obj), { [first]: setNestedValue((_b = obj === null || obj === void 0 ? void 0 : obj[first]) !== null && _b !== void 0 ? _b : (typeof rest[0] === "number" ? [] : {}), rest, val) });
+            };
+            const updated = setNestedValue(prevValues, path, newValue);
+            const topKey = path[0];
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            return updated;
+        });
     };
     const resetForm = () => {
         setValues(initialValues);
         setErrors({});
+        setDirtyFields(initialDirty);
     };
     const validate = (0, react_1.useCallback)(() => {
         if (!validationRules) {
@@ -46,6 +79,8 @@ const useForm = (initialValues, validationRules) => {
         values,
         setters,
         errors,
+        dirtyFields,
+        isDirty,
         handleChange,
         resetForm,
         validate,

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -5,10 +5,13 @@ export type ValidationRules<T> = {
     [K in keyof T]?: (value: T[K], values: T) => string | null;
 };
 type Errors<T> = Partial<Record<keyof T, string>>;
+type DirtyFields<T> = Record<keyof T, boolean>;
 interface UseForm<T> {
     values: T;
     setters: Setters<T>;
     errors: Errors<T>;
+    dirtyFields: DirtyFields<T>;
+    isDirty: boolean;
     handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     resetForm: () => void;
     validate: () => boolean;


### PR DESCRIPTION
## Summary
- track field changes with `dirtyFields` and `isDirty`
- reset dirty state on `resetForm`
- document dirty state usage in README
- rebuild distribution files

## Testing
- `pnpm test` *(fails: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68517e9690d4832ea6eca1d701c8d3da