### PR TITLE
Add promise-based validation

### DIFF
--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -1,4 +1,13 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useForm = void 0;
 const react_1 = require("react");
@@ -55,23 +64,23 @@ const useForm = (initialValues, validationRules) => {
         setErrors({});
         setDirtyFields(initialDirty);
     };
-    const validate = (0, react_1.useCallback)(() => {
+    const validate = (0, react_1.useCallback)(() => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {
             return true;
         }
         const newErrors = {};
-        Object.keys(validationRules).forEach((key) => {
+        yield Promise.all(Object.keys(validationRules).map((key) => __awaiter(void 0, void 0, void 0, function* () {
             const rule = validationRules[key];
             if (rule) {
-                const error = rule(values[key], values);
+                const error = yield rule(values[key], values);
                 if (error) {
                     newErrors[key] = error;
                 }
             }
-        });
+        })));
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
-    }, [validationRules, values]);
+    }), [validationRules, values]);
     const watch = (0, react_1.useCallback)((key) => {
         return key ? values[key] : values;
     }, [values]);

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -1,3 +1,12 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import { useCallback, useState } from "react";
 export const useForm = (initialValues, validationRules) => {
     const [values, setValues] = useState(initialValues);
@@ -52,23 +61,23 @@ export const useForm = (initialValues, validationRules) => {
         setErrors({});
         setDirtyFields(initialDirty);
     };
-    const validate = useCallback(() => {
+    const validate = useCallback(() => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {
             return true;
         }
         const newErrors = {};
-        Object.keys(validationRules).forEach((key) => {
+        yield Promise.all(Object.keys(validationRules).map((key) => __awaiter(void 0, void 0, void 0, function* () {
             const rule = validationRules[key];
             if (rule) {
-                const error = rule(values[key], values);
+                const error = yield rule(values[key], values);
                 if (error) {
                     newErrors[key] = error;
                 }
             }
-        });
+        })));
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
-    }, [validationRules, values]);
+    }), [validationRules, values]);
     const watch = useCallback((key) => {
         return key ? values[key] : values;
     }, [values]);

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -2,7 +2,7 @@ type Setters<T> = {
     [K in keyof T]: (value: T[K]) => void;
 };
 export type ValidationRules<T> = {
-    [K in keyof T]?: (value: T[K], values: T) => string | null;
+    [K in keyof T]?: (value: T[K], values: T) => string | null | Promise<string | null>;
 };
 type Errors<T> = Partial<Record<keyof T, string>>;
 type DirtyFields<T> = Record<keyof T, boolean>;
@@ -14,7 +14,7 @@ interface UseForm<T> {
     isDirty: boolean;
     handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     resetForm: () => void;
-    validate: () => boolean;
+    validate: () => Promise<boolean>;
     watch: <K extends keyof T>(key?: K) => T[K] | T;
 }
 export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>) => UseForm<T>;


### PR DESCRIPTION
## Summary
- support async validation in `useForm`
- rebuild dist
- document async usage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68517fdb3dcc832eb6d7b7f88deec14e