### PR TITLE
Add handleSubmit helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ interface FormData {
 }
 
 const MyForm = () => {
-  const { values, errors, dirtyFields, isDirty, handleChange, resetForm, validate } = useForm<FormData>(
+  const { values, errors, dirtyFields, isDirty, handleChange, handleSubmit, resetForm, validate } = useForm<FormData>(
     {
       username: "",
       email: "",
@@ -63,14 +63,12 @@ const MyForm = () => {
     }
   );
 
-  const onSubmit = async () => {
-    if (await validate()) {
-      console.log("submit", values);
-    }
+  const onSubmit = () => {
+    console.log("submit", values);
   };
 
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <input
         name='username'
         value={values.username}
@@ -190,19 +188,17 @@ const checkUsername = async (u: string) => {
 };
 
 const App = () => {
-  const { values, handleChange, validate, errors } = useForm<FormData>(
+  const { values, handleChange, handleSubmit, validate, errors } = useForm<FormData>(
     { username: "" },
     { username: checkUsername }
   );
 
-  const onSubmit = async () => {
-    if (await validate()) {
-      console.log("submit", values);
-    }
+  const onSubmit = () => {
+    console.log("submit", values);
   };
 
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <input
         name="username"
         value={values.username}
@@ -231,7 +227,7 @@ interface FormData {
 }
 
 const ComplexForm = () => {
-  const { values, setters, validate, errors } = useForm<FormData>(
+  const { values, setters, handleChange, handleSubmit, validate, errors } = useForm<FormData>(
     {
       user: { firstName: "", lastName: "" },
       tags: [],
@@ -245,8 +241,12 @@ const ComplexForm = () => {
 
   const addTag = () => setters.tags([...values.tags, ""]);
 
+  const onSubmit = () => {
+    console.log(values);
+  };
+
   return (
-    <form onSubmit={async (e) => { e.preventDefault(); await validate(); }}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <input
         name="user.firstName"
         value={values.user.firstName}
@@ -295,6 +295,7 @@ A custom hook that provides utilities for managing form state.
 - `values`: Current state of the form.
 - `setters`: A dynamic object containing setter functions for each field.
 - `handleChange`: A function to handle onChange events for input fields.
+- `handleSubmit`: Wraps validation and `event.preventDefault` for easier form submission.
 - `resetForm`: Resets the form to its initial values.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `errors`: Object containing validation errors.
@@ -312,6 +313,7 @@ const {
   dirtyFields,
   isDirty,
   handleChange,
+  handleSubmit,
   resetForm,
   validate,
   watch,

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -84,6 +84,12 @@ const useForm = (initialValues, validationRules) => {
     const watch = (0, react_1.useCallback)((key) => {
         return key ? values[key] : values;
     }, [values]);
+    const handleSubmit = (0, react_1.useCallback)((cb) => (e) => __awaiter(void 0, void 0, void 0, function* () {
+        e.preventDefault();
+        if (yield validate()) {
+            yield cb();
+        }
+    }), [validate]);
     return {
         values,
         setters,
@@ -91,6 +97,7 @@ const useForm = (initialValues, validationRules) => {
         dirtyFields,
         isDirty,
         handleChange,
+        handleSubmit,
         resetForm,
         validate,
         watch,

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -81,6 +81,12 @@ export const useForm = (initialValues, validationRules) => {
     const watch = useCallback((key) => {
         return key ? values[key] : values;
     }, [values]);
+    const handleSubmit = useCallback((cb) => (e) => __awaiter(void 0, void 0, void 0, function* () {
+        e.preventDefault();
+        if (yield validate()) {
+            yield cb();
+        }
+    }), [validate]);
     return {
         values,
         setters,
@@ -88,6 +94,7 @@ export const useForm = (initialValues, validationRules) => {
         dirtyFields,
         isDirty,
         handleChange,
+        handleSubmit,
         resetForm,
         validate,
         watch,

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -13,6 +13,7 @@ interface UseForm<T> {
     dirtyFields: DirtyFields<T>;
     isDirty: boolean;
     handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+    handleSubmit: (cb: () => void | Promise<void>) => (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
     resetForm: () => void;
     validate: () => Promise<boolean>;
     watch: <K extends keyof T>(key?: K) => T[K] | T;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -30,6 +30,9 @@ interface UseForm<T> {
       HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
     >
   ) => void;
+  handleSubmit: (
+    cb: () => void | Promise<void>
+  ) => (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
   resetForm: () => void;
   validate: () => Promise<boolean>;
   watch: <K extends keyof T>(key?: K) => T[K] | T;
@@ -157,6 +160,17 @@ export const useForm = <T extends Record<string, any>>(
     [values]
   );
 
+  const handleSubmit = useCallback(
+    (cb: () => void | Promise<void>) =>
+      async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (await validate()) {
+          await cb();
+        }
+      },
+    [validate]
+  );
+
   return {
     values,
     setters,
@@ -164,6 +178,7 @@ export const useForm = <T extends Record<string, any>>(
     dirtyFields,
     isDirty,
     handleChange,
+    handleSubmit,
     resetForm,
     validate,
     watch,


### PR DESCRIPTION
## Summary
- support `handleSubmit` in `useForm`
- document `handleSubmit` usage
- rebuild dist files

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685183ea6ea8832e894c99e6933a3038