### PR TITLE
Add touched field tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Designed to provide a simple and intuitive API for common form needs, including 
 👀 Watch Functionality: Track individual fields or the entire form state in real-time.
 
 📝 Dirty State Tracking: `dirtyFields` and `isDirty` indicate modified fields and overall form changes.
+🙌 Touched State Tracking: `touchedFields` and `isTouched` tell you which fields have been blurred.
 
 🔄 Reset Support: Easily reset form values to their initial state.
 
@@ -52,7 +53,7 @@ interface FormData {
 }
 
 const MyForm = () => {
-  const { values, errors, dirtyFields, isDirty, handleChange, handleSubmit, resetForm, validate } = useForm<FormData>(
+  const { values, errors, dirtyFields, isDirty, touchedFields, isTouched, handleChange, handleBlur, handleSubmit, resetForm, validate } = useForm<FormData>(
     {
       username: "",
       email: "",
@@ -73,6 +74,7 @@ const MyForm = () => {
         name='username'
         value={values.username}
         onChange={handleChange}
+        onBlur={handleBlur}
         placeholder='Username'
       />
       {errors.username && <span>{errors.username}</span>}
@@ -80,6 +82,7 @@ const MyForm = () => {
         name='email'
         value={values.email}
         onChange={handleChange}
+        onBlur={handleBlur}
         placeholder='Email'
       />
       {errors.email && <span>{errors.email}</span>}
@@ -90,7 +93,7 @@ const MyForm = () => {
 };
 ```
 
-`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. Calling `resetForm` clears both states.
+`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. `touchedFields` and `isTouched` track fields that have been blurred. Calling `resetForm` clears all of these states.
 
 ## Advanced Example with Watch
 
@@ -296,12 +299,15 @@ A custom hook that provides utilities for managing form state.
 - `setters`: A dynamic object containing setter functions for each field.
 - `handleChange`: A function to handle onChange events for input fields.
 - `handleSubmit`: Wraps validation and `event.preventDefault` for easier form submission.
+- `handleBlur`: Marks a field as touched when an input loses focus.
 - `resetForm`: Resets the form to its initial values.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `errors`: Object containing validation errors.
 - `validate`: Run validation and update the errors state. Returns a promise that resolves to `true` when the form is valid.
 - `dirtyFields`: Object tracking which fields have been modified.
 - `isDirty`: `true` when any field has changed.
+- `touchedFields`: Object tracking which fields have been blurred.
+- `isTouched`: `true` when any field has been touched.
 
 ### Example
 
@@ -312,7 +318,10 @@ const {
   setters,
   dirtyFields,
   isDirty,
+  touchedFields,
+  isTouched,
   handleChange,
+  handleBlur,
   handleSubmit,
   resetForm,
   validate,

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -19,7 +19,13 @@ const useForm = (initialValues, validationRules) => {
         return acc;
     }, {});
     const [dirtyFields, setDirtyFields] = (0, react_1.useState)(initialDirty);
+    const initialTouched = Object.keys(initialValues).reduce((acc, key) => {
+        acc[key] = false;
+        return acc;
+    }, {});
+    const [touchedFields, setTouchedFields] = (0, react_1.useState)(initialTouched);
     const isDirty = Object.keys(initialValues).some((k) => dirtyFields[k]);
+    const isTouched = Object.keys(initialValues).some((k) => touchedFields[k]);
     const setters = Object.keys(initialValues).reduce((acc, key) => {
         acc[key] = (value) => {
             setValues((prevValues) => {
@@ -56,13 +62,23 @@ const useForm = (initialValues, validationRules) => {
             const updated = setNestedValue(prevValues, path, newValue);
             const topKey = path[0];
             setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
             return updated;
         });
+    };
+    const handleBlur = (e) => {
+        const path = e.target.name
+            .replace(/\[(\w+)\]/g, ".$1")
+            .split(".")
+            .filter(Boolean);
+        const topKey = path[0];
+        setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
     };
     const resetForm = () => {
         setValues(initialValues);
         setErrors({});
         setDirtyFields(initialDirty);
+        setTouchedFields(initialTouched);
     };
     const validate = (0, react_1.useCallback)(() => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {
@@ -96,7 +112,10 @@ const useForm = (initialValues, validationRules) => {
         errors,
         dirtyFields,
         isDirty,
+        touchedFields,
+        isTouched,
         handleChange,
+        handleBlur,
         handleSubmit,
         resetForm,
         validate,

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -16,7 +16,13 @@ export const useForm = (initialValues, validationRules) => {
         return acc;
     }, {});
     const [dirtyFields, setDirtyFields] = useState(initialDirty);
+    const initialTouched = Object.keys(initialValues).reduce((acc, key) => {
+        acc[key] = false;
+        return acc;
+    }, {});
+    const [touchedFields, setTouchedFields] = useState(initialTouched);
     const isDirty = Object.keys(initialValues).some((k) => dirtyFields[k]);
+    const isTouched = Object.keys(initialValues).some((k) => touchedFields[k]);
     const setters = Object.keys(initialValues).reduce((acc, key) => {
         acc[key] = (value) => {
             setValues((prevValues) => {
@@ -53,13 +59,23 @@ export const useForm = (initialValues, validationRules) => {
             const updated = setNestedValue(prevValues, path, newValue);
             const topKey = path[0];
             setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
             return updated;
         });
+    };
+    const handleBlur = (e) => {
+        const path = e.target.name
+            .replace(/\[(\w+)\]/g, ".$1")
+            .split(".")
+            .filter(Boolean);
+        const topKey = path[0];
+        setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
     };
     const resetForm = () => {
         setValues(initialValues);
         setErrors({});
         setDirtyFields(initialDirty);
+        setTouchedFields(initialTouched);
     };
     const validate = useCallback(() => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {
@@ -93,7 +109,10 @@ export const useForm = (initialValues, validationRules) => {
         errors,
         dirtyFields,
         isDirty,
+        touchedFields,
+        isTouched,
         handleChange,
+        handleBlur,
         handleSubmit,
         resetForm,
         validate,

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -6,13 +6,17 @@ export type ValidationRules<T> = {
 };
 type Errors<T> = Partial<Record<keyof T, string>>;
 type DirtyFields<T> = Record<keyof T, boolean>;
+type TouchedFields<T> = Record<keyof T, boolean>;
 interface UseForm<T> {
     values: T;
     setters: Setters<T>;
     errors: Errors<T>;
     dirtyFields: DirtyFields<T>;
     isDirty: boolean;
+    touchedFields: TouchedFields<T>;
+    isTouched: boolean;
     handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+    handleBlur: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     handleSubmit: (cb: () => void | Promise<void>) => (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
     resetForm: () => void;
     validate: () => Promise<boolean>;


### PR DESCRIPTION
## Summary
- extend `UseForm` API with touched state and `handleBlur`
- implement touched field tracking in `useForm`
- reset touched flags when resetting a form
- document touched state and `handleBlur` usage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68518713697c832e9e210af1139c26c8