### PR TITLE
Implement setFieldValue helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,16 @@ const ComplexForm = () => {
 };
 ```
 
+You can also update fields programmatically using the same path syntax:
+
+```tsx
+const { setFieldValue } = useForm({
+  user: { address: { city: "" } },
+});
+
+setFieldValue("user.address.city", "New York");
+```
+
 ## API
 
 `useForm<T>(initialValues: T, validationRules?: ValidationRules<T>): UseForm<T>`
@@ -302,6 +312,7 @@ A custom hook that provides utilities for managing form state.
 - `handleBlur`: Marks a field as touched when an input loses focus.
 - `resetForm`: Resets the form to its initial values.
 - `watch`: A function to track specific fields or the entire form state in real-time.
+- `setFieldValue`: Programmatically update any field by path.
 - `errors`: Object containing validation errors.
 - `validate`: Run validation and update the errors state. Returns a promise that resolves to `true` when the form is valid.
 - `dirtyFields`: Object tracking which fields have been modified.
@@ -326,6 +337,7 @@ const {
   resetForm,
   validate,
   watch,
+  setFieldValue,
 } = useForm(
   { username: "", email: "" },
   {

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -66,6 +66,32 @@ const useForm = (initialValues, validationRules) => {
             return updated;
         });
     };
+    const setFieldValue = (0, react_1.useCallback)((pathString, newValue) => {
+        setValues((prevValues) => {
+            const path = pathString
+                .replace(/\[(\w+)\]/g, ".$1")
+                .split(".")
+                .filter(Boolean)
+                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const setNestedValue = (obj, keys, val) => {
+                var _a, _b;
+                if (!keys.length)
+                    return val;
+                const [first, ...rest] = keys;
+                if (Array.isArray(obj)) {
+                    const arr = [...obj];
+                    arr[first] = setNestedValue((_a = arr[first]) !== null && _a !== void 0 ? _a : (typeof rest[0] === "number" ? [] : {}), rest, val);
+                    return arr;
+                }
+                return Object.assign(Object.assign({}, obj), { [first]: setNestedValue((_b = obj === null || obj === void 0 ? void 0 : obj[first]) !== null && _b !== void 0 ? _b : (typeof rest[0] === "number" ? [] : {}), rest, val) });
+            };
+            const updated = setNestedValue(prevValues, path, newValue);
+            const topKey = path[0];
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
+            return updated;
+        });
+    }, []);
     const handleBlur = (e) => {
         const path = e.target.name
             .replace(/\[(\w+)\]/g, ".$1")
@@ -120,6 +146,7 @@ const useForm = (initialValues, validationRules) => {
         resetForm,
         validate,
         watch,
+        setFieldValue,
     };
 };
 exports.useForm = useForm;

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -63,6 +63,32 @@ export const useForm = (initialValues, validationRules) => {
             return updated;
         });
     };
+    const setFieldValue = useCallback((pathString, newValue) => {
+        setValues((prevValues) => {
+            const path = pathString
+                .replace(/\[(\w+)\]/g, ".$1")
+                .split(".")
+                .filter(Boolean)
+                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const setNestedValue = (obj, keys, val) => {
+                var _a, _b;
+                if (!keys.length)
+                    return val;
+                const [first, ...rest] = keys;
+                if (Array.isArray(obj)) {
+                    const arr = [...obj];
+                    arr[first] = setNestedValue((_a = arr[first]) !== null && _a !== void 0 ? _a : (typeof rest[0] === "number" ? [] : {}), rest, val);
+                    return arr;
+                }
+                return Object.assign(Object.assign({}, obj), { [first]: setNestedValue((_b = obj === null || obj === void 0 ? void 0 : obj[first]) !== null && _b !== void 0 ? _b : (typeof rest[0] === "number" ? [] : {}), rest, val) });
+            };
+            const updated = setNestedValue(prevValues, path, newValue);
+            const topKey = path[0];
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
+            return updated;
+        });
+    }, []);
     const handleBlur = (e) => {
         const path = e.target.name
             .replace(/\[(\w+)\]/g, ".$1")
@@ -117,5 +143,6 @@ export const useForm = (initialValues, validationRules) => {
         resetForm,
         validate,
         watch,
+        setFieldValue,
     };
 };

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -21,6 +21,7 @@ interface UseForm<T> {
     resetForm: () => void;
     validate: () => Promise<boolean>;
     watch: <K extends keyof T>(key?: K) => T[K] | T;
+    setFieldValue: (path: string, value: any) => void;
 }
 export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>) => UseForm<T>;
 export {};


### PR DESCRIPTION
## Summary
- add `setFieldValue` method to update fields programmatically
- expose it via the hook return object
- document usage in README
- rebuild dist files

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6851886fdf38832eb9651a218e48ce33