### PR TITLE
Support nested watch paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,20 @@ const App = () => {
 export default App;
 ```
 
+### Watching Nested Fields
+
+`watch` also accepts dot or bracket notation to access nested values:
+
+```tsx
+const { watch } = useForm({
+  user: { firstName: "", lastName: "" },
+  tags: ["react"]
+});
+
+const first = watch("user.firstName");
+const firstTag = watch("tags[0]");
+```
+
 ## Async Validation Example
 
 Validation rules can return promises, enabling checks like verifying username availability:

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -123,9 +123,21 @@ const useForm = (initialValues, validationRules) => {
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
     }), [validationRules, values]);
-    const watch = (0, react_1.useCallback)((key) => {
-        return key ? values[key] : values;
-    }, [values]);
+    function watch(path) {
+        if (!path) {
+            return values;
+        }
+        if (typeof path === "string" && (path.includes(".") || path.includes("["))) {
+            const segments = path
+                .replace(/\[(\w+)\]/g, ".$1")
+                .split(".")
+                .filter(Boolean)
+                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            return segments.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
+        }
+        return values[path];
+    }
+    const watchCallback = (0, react_1.useCallback)(watch, [values]);
     const handleSubmit = (0, react_1.useCallback)((cb) => (e) => __awaiter(void 0, void 0, void 0, function* () {
         e.preventDefault();
         if (yield validate()) {
@@ -145,7 +157,7 @@ const useForm = (initialValues, validationRules) => {
         handleSubmit,
         resetForm,
         validate,
-        watch,
+        watch: watchCallback,
         setFieldValue,
     };
 };

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -120,9 +120,21 @@ export const useForm = (initialValues, validationRules) => {
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
     }), [validationRules, values]);
-    const watch = useCallback((key) => {
-        return key ? values[key] : values;
-    }, [values]);
+    function watch(path) {
+        if (!path) {
+            return values;
+        }
+        if (typeof path === "string" && (path.includes(".") || path.includes("["))) {
+            const segments = path
+                .replace(/\[(\w+)\]/g, ".$1")
+                .split(".")
+                .filter(Boolean)
+                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            return segments.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
+        }
+        return values[path];
+    }
+    const watchCallback = useCallback(watch, [values]);
     const handleSubmit = useCallback((cb) => (e) => __awaiter(void 0, void 0, void 0, function* () {
         e.preventDefault();
         if (yield validate()) {
@@ -142,7 +154,7 @@ export const useForm = (initialValues, validationRules) => {
         handleSubmit,
         resetForm,
         validate,
-        watch,
+        watch: watchCallback,
         setFieldValue,
     };
 };

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -20,7 +20,11 @@ interface UseForm<T> {
     handleSubmit: (cb: () => void | Promise<void>) => (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
     resetForm: () => void;
     validate: () => Promise<boolean>;
-    watch: <K extends keyof T>(key?: K) => T[K] | T;
+    watch: {
+        (): T;
+        <K extends keyof T>(key: K): T[K];
+        (path: string): any;
+    };
     setFieldValue: (path: string, value: any) => void;
 }
 export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>) => UseForm<T>;


### PR DESCRIPTION
## Summary
- allow `watch` to accept nested paths like `"user.firstName"` or `"tags[0]"`
- update types for `watch`
- document nested `watch` usage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851a64b9f54832e865a6a191c1f9766