### PR TITLE
Add support for resetting form with new defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Designed to provide a simple and intuitive API for common form needs, including 
 📝 Dirty State Tracking: `dirtyFields` and `isDirty` indicate modified fields and overall form changes.
 🙌 Touched State Tracking: `touchedFields` and `isTouched` tell you which fields have been blurred.
 
-🔄 Reset Support: Easily reset form values to their initial state.
+🔄 Reset Support: Easily reset form values to their initial state or new defaults.
 
 🪶 Lightweight: No unnecessary overhead, just what you need for managing form state in React.
 
@@ -93,7 +93,11 @@ const MyForm = () => {
 };
 ```
 
-`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. `touchedFields` and `isTouched` track fields that have been blurred. Calling `resetForm` clears all of these states.
+`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. `touchedFields` and `isTouched` track fields that have been blurred. Calling `resetForm` clears all of these states. Pass new defaults to `resetForm` if you want to start over with a different initial state.
+
+```tsx
+resetForm({ username: "", email: "" });
+```
 
 ## Advanced Example with Watch
 
@@ -324,7 +328,7 @@ A custom hook that provides utilities for managing form state.
 - `handleChange`: A function to handle onChange events for input fields.
 - `handleSubmit`: Wraps validation and `event.preventDefault` for easier form submission.
 - `handleBlur`: Marks a field as touched when an input loses focus.
-- `resetForm`: Resets the form to its initial values.
+- `resetForm`: Resets the form to its initial values. Pass new defaults to `resetForm` to update the initial state.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `setFieldValue`: Programmatically update any field by path.
 - `errors`: Object containing validation errors.

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -12,25 +12,26 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.useForm = void 0;
 const react_1 = require("react");
 const useForm = (initialValues, validationRules) => {
-    const [values, setValues] = (0, react_1.useState)(initialValues);
+    const initialRef = (0, react_1.useRef)(initialValues);
+    const [values, setValues] = (0, react_1.useState)(initialRef.current);
     const [errors, setErrors] = (0, react_1.useState)({});
-    const initialDirty = Object.keys(initialValues).reduce((acc, key) => {
+    const initialDirty = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
     }, {});
     const [dirtyFields, setDirtyFields] = (0, react_1.useState)(initialDirty);
-    const initialTouched = Object.keys(initialValues).reduce((acc, key) => {
+    const initialTouched = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
     }, {});
     const [touchedFields, setTouchedFields] = (0, react_1.useState)(initialTouched);
-    const isDirty = Object.keys(initialValues).some((k) => dirtyFields[k]);
-    const isTouched = Object.keys(initialValues).some((k) => touchedFields[k]);
-    const setters = Object.keys(initialValues).reduce((acc, key) => {
+    const isDirty = Object.keys(initialRef.current).some((k) => dirtyFields[k]);
+    const isTouched = Object.keys(initialRef.current).some((k) => touchedFields[k]);
+    const setters = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = (value) => {
             setValues((prevValues) => {
                 const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
-                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialValues[key] })));
+                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialRef.current[key] })));
                 return newValues;
             });
         };
@@ -61,7 +62,7 @@ const useForm = (initialValues, validationRules) => {
             };
             const updated = setNestedValue(prevValues, path, newValue);
             const topKey = path[0];
-            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialRef.current[topKey] })));
             setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
             return updated;
         });
@@ -87,7 +88,7 @@ const useForm = (initialValues, validationRules) => {
             };
             const updated = setNestedValue(prevValues, path, newValue);
             const topKey = path[0];
-            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialRef.current[topKey] })));
             setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
             return updated;
         });
@@ -100,11 +101,23 @@ const useForm = (initialValues, validationRules) => {
         const topKey = path[0];
         setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
     };
-    const resetForm = () => {
-        setValues(initialValues);
+    const resetForm = (nextInitial) => {
+        if (nextInitial) {
+            initialRef.current = nextInitial;
+        }
+        const base = nextInitial !== null && nextInitial !== void 0 ? nextInitial : initialRef.current;
+        setValues(base);
         setErrors({});
-        setDirtyFields(initialDirty);
-        setTouchedFields(initialTouched);
+        const newDirty = Object.keys(initialRef.current).reduce((acc, key) => {
+            acc[key] = false;
+            return acc;
+        }, {});
+        setDirtyFields(newDirty);
+        const newTouched = Object.keys(initialRef.current).reduce((acc, key) => {
+            acc[key] = false;
+            return acc;
+        }, {});
+        setTouchedFields(newTouched);
     };
     const validate = (0, react_1.useCallback)(() => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -7,27 +7,28 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { useCallback, useState } from "react";
+import { useCallback, useState, useRef } from "react";
 export const useForm = (initialValues, validationRules) => {
-    const [values, setValues] = useState(initialValues);
+    const initialRef = useRef(initialValues);
+    const [values, setValues] = useState(initialRef.current);
     const [errors, setErrors] = useState({});
-    const initialDirty = Object.keys(initialValues).reduce((acc, key) => {
+    const initialDirty = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
     }, {});
     const [dirtyFields, setDirtyFields] = useState(initialDirty);
-    const initialTouched = Object.keys(initialValues).reduce((acc, key) => {
+    const initialTouched = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
     }, {});
     const [touchedFields, setTouchedFields] = useState(initialTouched);
-    const isDirty = Object.keys(initialValues).some((k) => dirtyFields[k]);
-    const isTouched = Object.keys(initialValues).some((k) => touchedFields[k]);
-    const setters = Object.keys(initialValues).reduce((acc, key) => {
+    const isDirty = Object.keys(initialRef.current).some((k) => dirtyFields[k]);
+    const isTouched = Object.keys(initialRef.current).some((k) => touchedFields[k]);
+    const setters = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = (value) => {
             setValues((prevValues) => {
                 const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
-                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialValues[key] })));
+                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialRef.current[key] })));
                 return newValues;
             });
         };
@@ -58,7 +59,7 @@ export const useForm = (initialValues, validationRules) => {
             };
             const updated = setNestedValue(prevValues, path, newValue);
             const topKey = path[0];
-            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialRef.current[topKey] })));
             setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
             return updated;
         });
@@ -84,7 +85,7 @@ export const useForm = (initialValues, validationRules) => {
             };
             const updated = setNestedValue(prevValues, path, newValue);
             const topKey = path[0];
-            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialValues[topKey] })));
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialRef.current[topKey] })));
             setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
             return updated;
         });
@@ -97,11 +98,23 @@ export const useForm = (initialValues, validationRules) => {
         const topKey = path[0];
         setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
     };
-    const resetForm = () => {
-        setValues(initialValues);
+    const resetForm = (nextInitial) => {
+        if (nextInitial) {
+            initialRef.current = nextInitial;
+        }
+        const base = nextInitial !== null && nextInitial !== void 0 ? nextInitial : initialRef.current;
+        setValues(base);
         setErrors({});
-        setDirtyFields(initialDirty);
-        setTouchedFields(initialTouched);
+        const newDirty = Object.keys(initialRef.current).reduce((acc, key) => {
+            acc[key] = false;
+            return acc;
+        }, {});
+        setDirtyFields(newDirty);
+        const newTouched = Object.keys(initialRef.current).reduce((acc, key) => {
+            acc[key] = false;
+            return acc;
+        }, {});
+        setTouchedFields(newTouched);
     };
     const validate = useCallback(() => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -18,7 +18,7 @@ interface UseForm<T> {
     handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     handleBlur: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     handleSubmit: (cb: () => void | Promise<void>) => (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
-    resetForm: () => void;
+    resetForm: (nextInitial?: T) => void;
     validate: () => Promise<boolean>;
     watch: {
         (): T;


### PR DESCRIPTION
## Summary
- allow `resetForm` to accept new initial values
- recompute dirty and touched when initial values change
- document resetting to new defaults

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851a9092c50832e9e6eacc8d0a665e1