### PR TITLE
Add isValid state to form hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ A custom hook that provides utilities for managing form state.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `setFieldValue`: Programmatically update any field by path.
 - `errors`: Object containing validation errors.
+- `isValid`: `true` when the form has no validation errors.
 - `validate`: Run validation and update the errors state. Returns a promise that resolves to `true` when the form is valid.
 - `dirtyFields`: Object tracking which fields have been modified.
 - `isDirty`: `true` when any field has changed.
@@ -344,6 +345,7 @@ A custom hook that provides utilities for managing form state.
 const {
   values,
   errors,
+  isValid,
   setters,
   dirtyFields,
   isDirty,

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -15,6 +15,7 @@ const useForm = (initialValues, validationRules) => {
     const initialRef = (0, react_1.useRef)(initialValues);
     const [values, setValues] = (0, react_1.useState)(initialRef.current);
     const [errors, setErrors] = (0, react_1.useState)({});
+    const [isValid, setIsValid] = (0, react_1.useState)(true);
     const initialDirty = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
@@ -108,6 +109,7 @@ const useForm = (initialValues, validationRules) => {
         const base = nextInitial !== null && nextInitial !== void 0 ? nextInitial : initialRef.current;
         setValues(base);
         setErrors({});
+        setIsValid(true);
         const newDirty = Object.keys(initialRef.current).reduce((acc, key) => {
             acc[key] = false;
             return acc;
@@ -119,23 +121,34 @@ const useForm = (initialValues, validationRules) => {
         }, {});
         setTouchedFields(newTouched);
     };
-    const validate = (0, react_1.useCallback)(() => __awaiter(void 0, void 0, void 0, function* () {
+    const runValidation = (0, react_1.useCallback)((vals) => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {
+            setIsValid(true);
             return true;
         }
         const newErrors = {};
         yield Promise.all(Object.keys(validationRules).map((key) => __awaiter(void 0, void 0, void 0, function* () {
             const rule = validationRules[key];
             if (rule) {
-                const error = yield rule(values[key], values);
+                const error = yield rule(vals[key], vals);
                 if (error) {
                     newErrors[key] = error;
                 }
             }
         })));
         setErrors(newErrors);
-        return Object.keys(newErrors).length === 0;
-    }), [validationRules, values]);
+        const valid = Object.keys(newErrors).length === 0;
+        setIsValid(valid);
+        return valid;
+    }), [validationRules]);
+    const validate = (0, react_1.useCallback)(() => __awaiter(void 0, void 0, void 0, function* () {
+        return runValidation(values);
+    }), [runValidation, values]);
+    (0, react_1.useEffect)(() => {
+        if (validationRules) {
+            runValidation(values);
+        }
+    }, [values, touchedFields, runValidation, validationRules]);
     function watch(path) {
         if (!path) {
             return values;
@@ -161,6 +174,7 @@ const useForm = (initialValues, validationRules) => {
         values,
         setters,
         errors,
+        isValid,
         dirtyFields,
         isDirty,
         touchedFields,

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -11,6 +11,7 @@ interface UseForm<T> {
     values: T;
     setters: Setters<T>;
     errors: Errors<T>;
+    isValid: boolean;
     dirtyFields: DirtyFields<T>;
     isDirty: boolean;
     touchedFields: TouchedFields<T>;


### PR DESCRIPTION
## Summary
- track form validity via new `isValid` state
- recompute validity on value/touch updates
- document `isValid` in API section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851ab343a88832e9c2cbb88d5506bc9