### PR TITLE
Add configurable validation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Designed to provide a simple and intuitive API for common form needs, including 
 ✅ Field-level Validation: Pass custom (sync or async) validation rules that receive both the field value and the full form state.
 
 ❌ Optional Validation: Define validation rules and control error state when needed.
+⚙️ Configurable Validation Triggers: Choose to validate on change, blur, or both.
 
 🌳 Nested Names: Use dot or bracket notation in `name` attributes to update nested fields automatically.
 
@@ -334,7 +335,7 @@ setFieldValue("user.address.city", "New York");
 
 ## API
 
-`useForm<T>(initialValues: T, validationRules?: ValidationRules<T>): UseForm<T>`
+`useForm<T>(initialValues: T, validationRules?: ValidationRules<T>, config?: { validateOnChange?: boolean; validateOnBlur?: boolean }): UseForm<T>`
 
 A custom hook that provides utilities for managing form state.
 
@@ -342,6 +343,7 @@ A custom hook that provides utilities for managing form state.
 
 - `initialValues`: An object representing the initial state of your form. The shape of this object defines the structure of the form.
 - `validationRules` *(optional)*: An object with validation functions (sync or async) for each field.
+- `config` *(optional)*: Object with `validateOnChange` and `validateOnBlur` booleans (both default to `true`) that control when automatic validation runs.
 
 #### Returns
 
@@ -384,6 +386,9 @@ const {
   { username: "", email: "" },
   {
     username: (v) => (!v ? "Required" : null),
+  },
+  {
+    validateOnChange: false,
   }
 );
 ```

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -11,7 +11,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useForm = void 0;
 const react_1 = require("react");
-const useForm = (initialValues, validationRules) => {
+const useForm = (initialValues, validationRules, config = {}) => {
+    const { validateOnChange = true, validateOnBlur = true } = config;
     const initialRef = (0, react_1.useRef)(initialValues);
     const [values, setValues] = (0, react_1.useState)(initialRef.current);
     const [errors, setErrors] = (0, react_1.useState)({});
@@ -164,10 +165,15 @@ const useForm = (initialValues, validationRules) => {
         return runValidation(values);
     }), [runValidation, values]);
     (0, react_1.useEffect)(() => {
-        if (validationRules) {
+        if (validateOnChange && validationRules) {
             runValidation(values);
         }
-    }, [values, touchedFields, runValidation, validationRules]);
+    }, [values, validateOnChange, runValidation, validationRules]);
+    (0, react_1.useEffect)(() => {
+        if (validateOnBlur && validationRules) {
+            runValidation(values);
+        }
+    }, [touchedFields, validateOnBlur, runValidation, validationRules]);
     function watch(path) {
         if (!path) {
             return values;

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -8,7 +8,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { useCallback, useState, useRef, useEffect } from "react";
-export const useForm = (initialValues, validationRules) => {
+export const useForm = (initialValues, validationRules, config = {}) => {
+    const { validateOnChange = true, validateOnBlur = true } = config;
     const initialRef = useRef(initialValues);
     const [values, setValues] = useState(initialRef.current);
     const [errors, setErrors] = useState({});
@@ -161,10 +162,15 @@ export const useForm = (initialValues, validationRules) => {
         return runValidation(values);
     }), [runValidation, values]);
     useEffect(() => {
-        if (validationRules) {
+        if (validateOnChange && validationRules) {
             runValidation(values);
         }
-    }, [values, touchedFields, runValidation, validationRules]);
+    }, [values, validateOnChange, runValidation, validationRules]);
+    useEffect(() => {
+        if (validateOnBlur && validationRules) {
+            runValidation(values);
+        }
+    }, [touchedFields, validateOnBlur, runValidation, validationRules]);
     function watch(path) {
         if (!path) {
             return values;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,2 @@
 export { useForm } from "./useForm";
+export type { UseFormConfig } from "./useForm";

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -7,6 +7,10 @@ export type ValidationRules<T> = {
 type Errors<T> = Partial<Record<keyof T, string>>;
 type DirtyFields<T> = Record<keyof T, boolean>;
 type TouchedFields<T> = Record<keyof T, boolean>;
+export interface UseFormConfig {
+    validateOnChange?: boolean;
+    validateOnBlur?: boolean;
+}
 interface UseForm<T> {
     values: T;
     setters: Setters<T>;
@@ -28,5 +32,5 @@ interface UseForm<T> {
     };
     setFieldValue: (path: string, value: any) => void;
 }
-export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>) => UseForm<T>;
+export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>, config?: UseFormConfig) => UseForm<T>;
 export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { useForm } from "./useForm";
+export type { UseFormConfig } from "./useForm";

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -20,6 +20,11 @@ type Errors<T> = Partial<Record<keyof T, string>>;
 type DirtyFields<T> = Record<keyof T, boolean>;
 type TouchedFields<T> = Record<keyof T, boolean>;
 
+export interface UseFormConfig {
+  validateOnChange?: boolean;
+  validateOnBlur?: boolean;
+}
+
 interface UseForm<T> {
   values: T;
   setters: Setters<T>;
@@ -54,8 +59,10 @@ interface UseForm<T> {
 
 export const useForm = <T extends Record<string, any>>(
   initialValues: T,
-  validationRules?: ValidationRules<T>
+  validationRules?: ValidationRules<T>,
+  config: UseFormConfig = {}
 ): UseForm<T> => {
+  const { validateOnChange = true, validateOnBlur = true } = config;
   const initialRef = useRef(initialValues);
   const [values, setValues] = useState<FormValues<T>>(initialRef.current);
   const [errors, setErrors] = useState<Errors<T>>({});
@@ -298,10 +305,16 @@ export const useForm = <T extends Record<string, any>>(
   }, [runValidation, values]);
 
   useEffect(() => {
-    if (validationRules) {
+    if (validateOnChange && validationRules) {
       runValidation(values);
     }
-  }, [values, touchedFields, runValidation, validationRules]);
+  }, [values, validateOnChange, runValidation, validationRules]);
+
+  useEffect(() => {
+    if (validateOnBlur && validationRules) {
+      runValidation(values);
+    }
+  }, [touchedFields, validateOnBlur, runValidation, validationRules]);
 
   function watch(): T;
   function watch<K extends keyof T>(key: K): T[K];


### PR DESCRIPTION
## Summary
- allow `useForm` to accept a new `UseFormConfig` with `validateOnChange` and `validateOnBlur` flags
- call validation only when the respective flag is enabled
- export `UseFormConfig`
- document the configuration and update example in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851b01b00b0832e926d381ef7319f87