### PR TITLE
Add field reset and submission helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Designed to provide a simple and intuitive API for common form needs, including 
 
 🔄 Reset Support: Easily reset form values to their initial state or new defaults.
 
+🧹 `resetField` to restore any field to its initial value.
+🚫 `clearErrors` to remove validation messages.
+⏳ `isSubmitting` flag while the submit callback runs.
+
 🪶 Lightweight: No unnecessary overhead, just what you need for managing form state in React.
 
 ✅ Field-level Validation: Pass custom (sync or async) validation rules that receive both the field value and the full form state.
@@ -54,7 +58,22 @@ interface FormData {
 }
 
 const MyForm = () => {
-  const { values, errors, dirtyFields, isDirty, touchedFields, isTouched, handleChange, handleBlur, handleSubmit, resetForm, validate } = useForm<FormData>(
+  const {
+    values,
+    errors,
+    dirtyFields,
+    isDirty,
+    touchedFields,
+    isTouched,
+    handleChange,
+    handleBlur,
+    handleSubmit,
+    resetForm,
+    resetField,
+    clearErrors,
+    isSubmitting,
+    validate
+  } = useForm<FormData>(
     {
       username: "",
       email: "",
@@ -87,14 +106,18 @@ const MyForm = () => {
         placeholder='Email'
       />
       {errors.email && <span>{errors.email}</span>}
-      <button type='submit'>Submit</button>
+      <button type='submit' disabled={isSubmitting}>
+        {isSubmitting ? 'Saving...' : 'Submit'}
+      </button>
+      <button type='button' onClick={() => resetField('username')}>Reset username</button>
+      <button type='button' onClick={() => clearErrors()}>Clear errors</button>
       <button type='button' onClick={resetForm}>Reset</button>
     </form>
   );
 };
 ```
 
-`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. `touchedFields` and `isTouched` track fields that have been blurred. Calling `resetForm` clears all of these states. Pass new defaults to `resetForm` if you want to start over with a different initial state.
+`dirtyFields` lets you know which fields changed from their initial value, while `isDirty` tells you if any field has been modified. `touchedFields` and `isTouched` track fields that have been blurred. Calling `resetForm` clears all of these states. Use `resetField` to restore a single field and `clearErrors()` to remove validation messages. The `isSubmitting` flag is `true` while the submit callback runs. Pass new defaults to `resetForm` if you want to start over with a different initial state.
 
 ```tsx
 resetForm({ username: "", email: "" });
@@ -353,10 +376,13 @@ A custom hook that provides utilities for managing form state.
 - `handleSubmit`: Wraps validation and `event.preventDefault` for easier form submission.
 - `handleBlur`: Marks a field as touched when an input loses focus.
 - `resetForm`: Resets the form to its initial values. Pass new defaults to `resetForm` to update the initial state.
+- `resetField`: Restore a single field to its initial value.
+- `clearErrors`: Remove error messages for a field or the whole form.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `setFieldValue`: Programmatically update any field by path.
 - `errors`: Object containing validation errors.
 - `isValid`: `true` when the form has no validation errors.
+- `isSubmitting`: `true` while `handleSubmit` is running.
 - `validate`: Run validation and update the errors state. Returns a promise that resolves to `true` when the form is valid.
 - `dirtyFields`: Object tracking which fields have been modified.
 - `isDirty`: `true` when any field has changed.
@@ -379,6 +405,9 @@ const {
   handleBlur,
   handleSubmit,
   resetForm,
+  resetField,
+  clearErrors,
+  isSubmitting,
   validate,
   watch,
   setFieldValue,

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -14,6 +14,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
     const [values, setValues] = useState(initialRef.current);
     const [errors, setErrors] = useState({});
     const [isValid, setIsValid] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const initialDirty = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
@@ -138,6 +139,48 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         }, {});
         setTouchedFields(newTouched);
     };
+    const resetField = (pathString) => {
+        const path = pathString
+            .replace(/\[(\w+)\]/g, ".$1")
+            .split(".")
+            .filter(Boolean)
+            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const topKey = path[0];
+        const getNested = (obj, keys) => keys.reduce((acc, key) => acc === null || acc === void 0 ? void 0 : acc[key], obj);
+        const initialVal = getNested(initialRef.current, path);
+        setValues((prev) => {
+            const setNested = (obj, keys, val) => {
+                var _a, _b;
+                if (!keys.length)
+                    return val;
+                const [first, ...rest] = keys;
+                if (Array.isArray(obj)) {
+                    const arr = [...obj];
+                    arr[first] = setNested((_a = arr[first]) !== null && _a !== void 0 ? _a : (typeof rest[0] === "number" ? [] : {}), rest, val);
+                    return arr;
+                }
+                return Object.assign(Object.assign({}, obj), { [first]: setNested((_b = obj === null || obj === void 0 ? void 0 : obj[first]) !== null && _b !== void 0 ? _b : (typeof rest[0] === "number" ? [] : {}), rest, val) });
+            };
+            const updated = setNested(prev, path, initialVal);
+            return updated;
+        });
+        setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: false })));
+        setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: false })));
+    };
+    const clearErrors = (pathString) => {
+        if (!pathString) {
+            setErrors({});
+            return;
+        }
+        const key = pathString
+            .replace(/\[(\w+)\]/g, ".$1")
+            .split(".")[0];
+        setErrors((e) => {
+            const ne = Object.assign({}, e);
+            delete ne[key];
+            return ne;
+        });
+    };
     const runValidation = useCallback((vals) => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRules) {
             setIsValid(true);
@@ -188,8 +231,14 @@ export const useForm = (initialValues, validationRules, config = {}) => {
     const watchCallback = useCallback(watch, [values]);
     const handleSubmit = useCallback((cb) => (e) => __awaiter(void 0, void 0, void 0, function* () {
         e.preventDefault();
-        if (yield validate()) {
-            yield cb();
+        setIsSubmitting(true);
+        try {
+            if (yield validate()) {
+                yield cb();
+            }
+        }
+        finally {
+            setIsSubmitting(false);
         }
     }), [validate]);
     return {
@@ -197,6 +246,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         setters,
         errors,
         isValid,
+        isSubmitting,
         dirtyFields,
         isDirty,
         touchedFields,
@@ -205,6 +255,8 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         handleBlur,
         handleSubmit,
         resetForm,
+        resetField,
+        clearErrors,
         validate,
         watch: watchCallback,
         setFieldValue,

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -16,6 +16,7 @@ interface UseForm<T> {
     setters: Setters<T>;
     errors: Errors<T>;
     isValid: boolean;
+    isSubmitting: boolean;
     dirtyFields: DirtyFields<T>;
     isDirty: boolean;
     touchedFields: TouchedFields<T>;
@@ -24,6 +25,8 @@ interface UseForm<T> {
     handleBlur: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
     handleSubmit: (cb: () => void | Promise<void>) => (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
     resetForm: (nextInitial?: T) => void;
+    resetField: (path: string) => void;
+    clearErrors: (path?: string) => void;
     validate: () => Promise<boolean>;
     watch: {
         (): T;


### PR DESCRIPTION
## Summary
- restore individual form fields via `resetField`
- add `clearErrors` for removing validation messages
- track `isSubmitting` during `handleSubmit`
- document new helpers in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851b1893980832eb49a928bab9b2fa7