### PR TITLE
Add registerField for dynamic form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Designed to provide a simple and intuitive API for common form needs, including 
 ⚙️ Configurable Validation Triggers: Choose to validate on change, blur, or both.
 
 🌳 Nested Names: Use dot or bracket notation in `name` attributes to update nested fields automatically.
+➕ Dynamic Field Registration with `registerField` for runtime fields.
 
 ## Installation
 
@@ -355,6 +356,14 @@ setFieldValue("user.address.city", "New York");
 </select>
 ```
 
+## Dynamic Field Registration
+
+Add fields after initialization using `registerField(path, initialValue)`.
+
+```tsx
+const { registerField } = useForm({});
+registerField("extra", "");
+```
 
 ## API
 
@@ -380,6 +389,7 @@ A custom hook that provides utilities for managing form state.
 - `clearErrors`: Remove error messages for a field or the whole form.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `setFieldValue`: Programmatically update any field by path.
+- `registerField`: Add new fields at runtime.
 - `errors`: Object containing validation errors.
 - `isValid`: `true` when the form has no validation errors.
 - `isSubmitting`: `true` while `handleSubmit` is running.

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -15,6 +15,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
     const [errors, setErrors] = useState({});
     const [isValid, setIsValid] = useState(true);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const validationRulesRef = useRef((validationRules !== null && validationRules !== void 0 ? validationRules : {}));
     const initialDirty = Object.keys(initialRef.current).reduce((acc, key) => {
         acc[key] = false;
         return acc;
@@ -112,6 +113,32 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             return updated;
         });
     }, []);
+    const registerField = useCallback((pathString, initialValue) => {
+        const path = pathString
+            .replace(/\[(\w+)\]/g, ".$1")
+            .split(".")
+            .filter(Boolean)
+            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const setNested = (obj, keys, val) => {
+            var _a, _b;
+            if (!keys.length)
+                return val;
+            const [first, ...rest] = keys;
+            if (Array.isArray(obj)) {
+                const arr = [...obj];
+                arr[first] = setNested((_a = arr[first]) !== null && _a !== void 0 ? _a : (typeof rest[0] === "number" ? [] : {}), rest, val);
+                return arr;
+            }
+            return Object.assign(Object.assign({}, obj), { [first]: setNested((_b = obj === null || obj === void 0 ? void 0 : obj[first]) !== null && _b !== void 0 ? _b : (typeof rest[0] === "number" ? [] : {}), rest, val) });
+        };
+        setValues((prev) => setNested(prev, path, initialValue));
+        initialRef.current = setNested(initialRef.current, path, initialValue);
+        setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [pathString]: false })));
+        setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [pathString]: false })));
+        if (!(pathString in validationRulesRef.current)) {
+            validationRulesRef.current[pathString] = undefined;
+        }
+    }, []);
     const handleBlur = (e) => {
         const path = e.target.name
             .replace(/\[(\w+)\]/g, ".$1")
@@ -182,13 +209,13 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         });
     };
     const runValidation = useCallback((vals) => __awaiter(void 0, void 0, void 0, function* () {
-        if (!validationRules) {
+        if (!validationRulesRef.current || Object.keys(validationRulesRef.current).length === 0) {
             setIsValid(true);
             return true;
         }
         const newErrors = {};
-        yield Promise.all(Object.keys(validationRules).map((key) => __awaiter(void 0, void 0, void 0, function* () {
-            const rule = validationRules[key];
+        yield Promise.all(Object.keys(validationRulesRef.current).map((key) => __awaiter(void 0, void 0, void 0, function* () {
+            const rule = validationRulesRef.current[key];
             if (rule) {
                 const error = yield rule(vals[key], vals);
                 if (error) {
@@ -200,20 +227,20 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         const valid = Object.keys(newErrors).length === 0;
         setIsValid(valid);
         return valid;
-    }), [validationRules]);
+    }), [validationRulesRef]);
     const validate = useCallback(() => __awaiter(void 0, void 0, void 0, function* () {
         return runValidation(values);
     }), [runValidation, values]);
     useEffect(() => {
-        if (validateOnChange && validationRules) {
+        if (validateOnChange && validationRulesRef.current) {
             runValidation(values);
         }
-    }, [values, validateOnChange, runValidation, validationRules]);
+    }, [values, validateOnChange, runValidation]);
     useEffect(() => {
-        if (validateOnBlur && validationRules) {
+        if (validateOnBlur && validationRulesRef.current) {
             runValidation(values);
         }
-    }, [touchedFields, validateOnBlur, runValidation, validationRules]);
+    }, [touchedFields, validateOnBlur, runValidation]);
     function watch(path) {
         if (!path) {
             return values;
@@ -260,5 +287,6 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         validate,
         watch: watchCallback,
         setFieldValue,
+        registerField,
     };
 };

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -3,16 +3,18 @@ type Setters<T> = {
 };
 export type ValidationRules<T> = {
     [K in keyof T]?: (value: T[K], values: T) => string | null | Promise<string | null>;
+} & {
+    [path: string]: (value: any, values: any) => string | null | Promise<string | null>;
 };
-type Errors<T> = Partial<Record<keyof T, string>>;
-type DirtyFields<T> = Record<keyof T, boolean>;
-type TouchedFields<T> = Record<keyof T, boolean>;
+type Errors<T> = Record<string, string>;
+type DirtyFields<T> = Record<string, boolean>;
+type TouchedFields<T> = Record<string, boolean>;
 export interface UseFormConfig {
     validateOnChange?: boolean;
     validateOnBlur?: boolean;
 }
 interface UseForm<T> {
-    values: T;
+    values: T & Record<string, any>;
     setters: Setters<T>;
     errors: Errors<T>;
     isValid: boolean;
@@ -34,6 +36,7 @@ interface UseForm<T> {
         (path: string): any;
     };
     setFieldValue: (path: string, value: any) => void;
+    registerField: (path: string, initialValue: any) => void;
 }
 export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>, config?: UseFormConfig) => UseForm<T>;
 export {};

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1,8 +1,6 @@
 import { useCallback, useState, useRef, useEffect } from "react";
 
-type FormValues<T> = {
-  [K in keyof T]: T[K];
-};
+type FormValues<T> = T & Record<string, any>;
 
 type Setters<T> = {
   [K in keyof T]: (value: T[K]) => void;
@@ -13,12 +11,14 @@ export type ValidationRules<T> = {
     value: T[K],
     values: T
   ) => string | null | Promise<string | null>;
+} & {
+  [path: string]: (value: any, values: any) => string | null | Promise<string | null>;
 };
 
-type Errors<T> = Partial<Record<keyof T, string>>;
+type Errors<T> = Record<string, string>;
 
-type DirtyFields<T> = Record<keyof T, boolean>;
-type TouchedFields<T> = Record<keyof T, boolean>;
+type DirtyFields<T> = Record<string, boolean>;
+type TouchedFields<T> = Record<string, boolean>;
 
 export interface UseFormConfig {
   validateOnChange?: boolean;
@@ -26,7 +26,7 @@ export interface UseFormConfig {
 }
 
 interface UseForm<T> {
-  values: T;
+  values: T & Record<string, any>;
   setters: Setters<T>;
   errors: Errors<T>;
   isValid: boolean;
@@ -58,6 +58,7 @@ interface UseForm<T> {
     (path: string): any;
   };
   setFieldValue: (path: string, value: any) => void;
+  registerField: (path: string, initialValue: any) => void;
 }
 
 export const useForm = <T extends Record<string, any>>(
@@ -71,22 +72,21 @@ export const useForm = <T extends Record<string, any>>(
   const [errors, setErrors] = useState<Errors<T>>({});
   const [isValid, setIsValid] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const validationRulesRef = useRef<ValidationRules<T>>(
+    (validationRules ?? {}) as ValidationRules<T>
+  );
   const initialDirty = Object.keys(initialRef.current).reduce((acc, key) => {
-    acc[key as keyof T] = false;
+    acc[key] = false;
     return acc;
   }, {} as DirtyFields<T>);
   const [dirtyFields, setDirtyFields] = useState<DirtyFields<T>>(initialDirty);
   const initialTouched = Object.keys(initialRef.current).reduce((acc, key) => {
-    acc[key as keyof T] = false;
+    acc[key] = false;
     return acc;
   }, {} as TouchedFields<T>);
   const [touchedFields, setTouchedFields] = useState<TouchedFields<T>>(initialTouched);
-  const isDirty = Object.keys(initialRef.current).some(
-    (k) => dirtyFields[k as keyof T]
-  );
-  const isTouched = Object.keys(initialRef.current).some(
-    (k) => touchedFields[k as keyof T]
-  );
+  const isDirty = Object.keys(initialRef.current).some((k) => dirtyFields[k]);
+  const isTouched = Object.keys(initialRef.current).some((k) => touchedFields[k]);
 
   const setters = Object.keys(initialRef.current).reduce((acc, key) => {
     acc[key as keyof T] = (value: any) => {
@@ -172,10 +172,10 @@ export const useForm = <T extends Record<string, any>>(
       };
 
       const updated = setNestedValue(prevValues, path, newValue);
-      const topKey = path[0] as keyof T;
+      const topKey = path[0] as string;
       setDirtyFields((d) => ({
         ...d,
-        [topKey]: updated[topKey] !== initialRef.current[topKey],
+        [topKey]: (updated as any)[topKey] !== (initialRef.current as any)[topKey],
       }));
       setTouchedFields((t) => ({
         ...t,
@@ -224,19 +224,64 @@ export const useForm = <T extends Record<string, any>>(
         };
 
         const updated = setNestedValue(prevValues, path, newValue);
-        const topKey = path[0] as keyof T;
+        const topKey = path[0] as string;
         setDirtyFields((d) => ({
           ...d,
-          [topKey]: updated[topKey] !== initialRef.current[topKey],
+          [topKey]: (updated as any)[topKey] !== (initialRef.current as any)[topKey],
         }));
         setTouchedFields((t) => ({
           ...t,
           [topKey]: true,
         }));
-        return updated;
-      });
+      return updated;
+    });
+  },
+  []
+  );
+
+  const registerField = useCallback(
+    (pathString: string, initialValue: any) => {
+      const path = pathString
+        .replace(/\[(\w+)\]/g, ".$1")
+        .split(".")
+        .filter(Boolean)
+        .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+
+      const setNested = (
+        obj: any,
+        keys: (string | number)[],
+        val: any
+      ): any => {
+        if (!keys.length) return val;
+        const [first, ...rest] = keys;
+        if (Array.isArray(obj)) {
+          const arr = [...obj];
+          arr[first as number] = setNested(
+            arr[first as number] ?? (typeof rest[0] === "number" ? [] : {}),
+            rest,
+            val
+          );
+          return arr;
+        }
+        return {
+          ...obj,
+          [first]: setNested(
+            obj?.[first] ?? (typeof rest[0] === "number" ? [] : {}),
+            rest,
+            val
+          )
+        };
+      };
+
+      setValues((prev) => setNested(prev, path, initialValue));
+      initialRef.current = setNested(initialRef.current, path, initialValue);
+      setDirtyFields((d) => ({ ...d, [pathString]: false }));
+      setTouchedFields((t) => ({ ...t, [pathString]: false }));
+      if (!(pathString in validationRulesRef.current)) {
+        (validationRulesRef.current as any)[pathString] = undefined as any;
+      }
     },
-    [],
+    []
   );
 
   const handleBlur = (
@@ -248,7 +293,7 @@ export const useForm = <T extends Record<string, any>>(
       .replace(/\[(\w+)\]/g, ".$1")
       .split(".")
       .filter(Boolean);
-    const topKey = path[0] as keyof T;
+    const topKey = path[0] as string;
     setTouchedFields((t) => ({
       ...t,
       [topKey]: true,
@@ -264,12 +309,12 @@ export const useForm = <T extends Record<string, any>>(
     setErrors({});
     setIsValid(true);
     const newDirty = Object.keys(initialRef.current).reduce((acc, key) => {
-      acc[key as keyof T] = false;
+      acc[key] = false;
       return acc;
     }, {} as DirtyFields<T>);
     setDirtyFields(newDirty);
     const newTouched = Object.keys(initialRef.current).reduce((acc, key) => {
-      acc[key as keyof T] = false;
+      acc[key] = false;
       return acc;
     }, {} as TouchedFields<T>);
     setTouchedFields(newTouched);
@@ -281,7 +326,7 @@ export const useForm = <T extends Record<string, any>>(
       .split(".")
       .filter(Boolean)
       .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
-    const topKey = path[0] as keyof T;
+    const topKey = path[0] as string;
 
     const getNested = (obj: any, keys: (string | number)[]): any =>
       keys.reduce<any>((acc, key) => acc?.[key], obj);
@@ -329,7 +374,7 @@ export const useForm = <T extends Record<string, any>>(
     }
     const key = pathString
       .replace(/\[(\w+)\]/g, ".$1")
-      .split(".")[0] as keyof T;
+      .split(".")[0];
     setErrors((e) => {
       const ne = { ...e };
       delete ne[key];
@@ -339,7 +384,7 @@ export const useForm = <T extends Record<string, any>>(
 
   const runValidation = useCallback(
     async (vals: T): Promise<boolean> => {
-      if (!validationRules) {
+      if (!validationRulesRef.current || Object.keys(validationRulesRef.current).length === 0) {
         setIsValid(true);
         return true;
       }
@@ -347,12 +392,12 @@ export const useForm = <T extends Record<string, any>>(
       const newErrors: Errors<T> = {};
 
       await Promise.all(
-        Object.keys(validationRules).map(async (key) => {
-          const rule = validationRules[key as keyof T];
+        Object.keys(validationRulesRef.current).map(async (key) => {
+          const rule = validationRulesRef.current[key];
           if (rule) {
-            const error = await rule(vals[key as keyof T], vals);
+            const error = await rule((vals as any)[key], vals);
             if (error) {
-              newErrors[key as keyof T] = error;
+              newErrors[key] = error;
             }
           }
         })
@@ -363,7 +408,7 @@ export const useForm = <T extends Record<string, any>>(
       setIsValid(valid);
       return valid;
     },
-    [validationRules]
+    [validationRulesRef]
   );
 
   const validate = useCallback(async (): Promise<boolean> => {
@@ -371,16 +416,16 @@ export const useForm = <T extends Record<string, any>>(
   }, [runValidation, values]);
 
   useEffect(() => {
-    if (validateOnChange && validationRules) {
+    if (validateOnChange && validationRulesRef.current) {
       runValidation(values);
     }
-  }, [values, validateOnChange, runValidation, validationRules]);
+  }, [values, validateOnChange, runValidation]);
 
   useEffect(() => {
-    if (validateOnBlur && validationRules) {
+    if (validateOnBlur && validationRulesRef.current) {
       runValidation(values);
     }
-  }, [touchedFields, validateOnBlur, runValidation, validationRules]);
+  }, [touchedFields, validateOnBlur, runValidation]);
 
   function watch(): T;
   function watch<K extends keyof T>(key: K): T[K];
@@ -399,7 +444,7 @@ export const useForm = <T extends Record<string, any>>(
       return segments.reduce<any>((acc, seg) => acc?.[seg], values);
     }
 
-    return values[path as keyof T];
+    return (values as any)[path];
   }
 
   const watchCallback = useCallback(watch, [values]) as {
@@ -443,5 +488,6 @@ export const useForm = <T extends Record<string, any>>(
     validate,
     watch: watchCallback,
     setFieldValue,
+    registerField,
   };
 };


### PR DESCRIPTION
## Summary
- allow runtime field registration via `registerField`
- relax types for dynamic field paths
- document dynamic field registration

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851b321bcf0832ea2ff335967ead758