### PR TITLE
Fix nested error clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Designed to provide a simple and intuitive API for common form needs, including 
 🔄 Reset Support: Easily reset form values to their initial state or new defaults.
 
 🧹 `resetField` to restore any field to its initial value.
-🚫 `clearErrors` to remove validation messages.
+🚫 `clearErrors` to remove validation messages (supports nested paths).
 ⏳ `isSubmitting` flag while the submit callback runs.
 
 🪶 Lightweight: No unnecessary overhead, just what you need for managing form state in React.
@@ -333,6 +333,7 @@ const { setFieldValue } = useForm({
 });
 
 setFieldValue("user.address.city", "New York");
+clearErrors("user.address.city");
 ```
 ## Handling Special Input Types
 
@@ -386,7 +387,7 @@ A custom hook that provides utilities for managing form state.
 - `handleBlur`: Marks a field as touched when an input loses focus.
 - `resetForm`: Resets the form to its initial values. Pass new defaults to `resetForm` to update the initial state.
 - `resetField`: Restore a single field to its initial value.
-- `clearErrors`: Remove error messages for a field or the whole form.
+- `clearErrors`: Remove error messages for a field or the whole form. Pass a nested path to target specific errors.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `setFieldValue`: Programmatically update any field by path.
 - `registerField`: Add new fields at runtime.

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -208,12 +208,16 @@ const useForm = (initialValues, validationRules, config = {}) => {
             setErrors({});
             return;
         }
-        const key = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")[0];
+        const normalized = pathString.replace(/\[(\w+)\]/g, ".$1").replace(/^\./, "");
         setErrors((e) => {
             const ne = Object.assign({}, e);
-            delete ne[key];
+            if (normalized in ne) {
+                delete ne[normalized];
+            }
+            else {
+                const topKey = normalized.split(".")[0];
+                delete ne[topKey];
+            }
             return ne;
         });
     };

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -205,12 +205,16 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             setErrors({});
             return;
         }
-        const key = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")[0];
+        const normalized = pathString.replace(/\[(\w+)\]/g, ".$1").replace(/^\./, "");
         setErrors((e) => {
             const ne = Object.assign({}, e);
-            delete ne[key];
+            if (normalized in ne) {
+                delete ne[normalized];
+            }
+            else {
+                const topKey = normalized.split(".")[0];
+                delete ne[topKey];
+            }
             return ne;
         });
     };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -386,12 +386,15 @@ export const useForm = <T extends Record<string, any>>(
       setErrors({});
       return;
     }
-    const key = pathString
-      .replace(/\[(\w+)\]/g, ".$1")
-      .split(".")[0];
+    const normalized = pathString.replace(/\[(\w+)\]/g, ".$1").replace(/^\./, "");
     setErrors((e) => {
       const ne = { ...e };
-      delete ne[key];
+      if (normalized in ne) {
+        delete ne[normalized];
+      } else {
+        const topKey = normalized.split(".")[0];
+        delete ne[topKey];
+      }
       return ne;
     });
   };


### PR DESCRIPTION
## Summary
- improve `clearErrors` to delete nested paths instead of the top-level key
- document nested error clearing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851b7df6480832e87c5451815c13aab