### PR TITLE
Add unregisterField support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Designed to provide a simple and intuitive API for common form needs, including 
 
 🌳 Nested Names: Use dot or bracket notation in `name` attributes to update nested fields automatically.
 ➕ Dynamic Field Registration with `registerField` for runtime fields.
+➖ Dynamic Field Unregistration with `unregisterField` to remove them.
 
 ## Installation
 
@@ -359,11 +360,12 @@ clearErrors("user.address.city");
 
 ## Dynamic Field Registration
 
-Add fields after initialization using `registerField(path, initialValue)`.
+Add fields after initialization using `registerField(path, initialValue)`. Remove them when no longer needed with `unregisterField(path)`.
 
 ```tsx
-const { registerField } = useForm({});
+const { registerField, unregisterField } = useForm({});
 registerField("extra", "");
+unregisterField("extra");
 ```
 
 ## API
@@ -391,6 +393,7 @@ A custom hook that provides utilities for managing form state.
 - `watch`: A function to track specific fields or the entire form state in real-time.
 - `setFieldValue`: Programmatically update any field by path.
 - `registerField`: Add new fields at runtime.
+- `unregisterField`: Remove a field and its state at runtime.
 - `errors`: Object containing validation errors.
 - `isValid`: `true` when the form has no validation errors.
 - `isSubmitting`: `true` while `handleSubmit` is running.
@@ -422,7 +425,9 @@ const {
   validate,
   watch,
   setFieldValue,
-} = useForm(
+  registerField,
+  unregisterField,
+  } = useForm(
   { username: "", email: "" },
   {
     username: (v) => (!v ? "Required" : null),

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -7,6 +7,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
 import { useCallback, useState, useRef, useEffect } from "react";
 export const useForm = (initialValues, validationRules, config = {}) => {
     const { validateOnChange = true, validateOnBlur = true } = config;
@@ -218,6 +229,48 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             return ne;
         });
     };
+    const unregisterField = useCallback((pathString) => {
+        const path = pathString
+            .replace(/\[(\w+)\]/g, ".$1")
+            .split(".")
+            .filter(Boolean)
+            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const removeNested = (obj, keys) => {
+            if (!obj)
+                return obj;
+            const [first, ...rest] = keys;
+            if (rest.length === 0) {
+                if (Array.isArray(obj)) {
+                    const arr = [...obj];
+                    arr.splice(first, 1);
+                    return arr;
+                }
+                const _a = obj, _b = first, _omit = _a[_b], restObj = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
+                return restObj;
+            }
+            if (Array.isArray(obj)) {
+                const arr = [...obj];
+                arr[first] = removeNested(arr[first], rest);
+                return arr;
+            }
+            return Object.assign(Object.assign({}, obj), { [first]: removeNested(obj[first], rest) });
+        };
+        const topKey = path[0];
+        initialRef.current = removeNested(initialRef.current, path);
+        setValues((prev) => removeNested(prev, path));
+        setDirtyFields((d) => {
+            const _a = d, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
+            return rest;
+        });
+        setTouchedFields((t) => {
+            const _a = t, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
+            return rest;
+        });
+        clearErrors(pathString);
+        if (pathString in validationRulesRef.current) {
+            delete validationRulesRef.current[pathString];
+        }
+    }, []);
     const runValidation = useCallback((vals) => __awaiter(void 0, void 0, void 0, function* () {
         if (!validationRulesRef.current || Object.keys(validationRulesRef.current).length === 0) {
             setIsValid(true);
@@ -298,5 +351,6 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         watch: watchCallback,
         setFieldValue,
         registerField,
+        unregisterField,
     };
 };

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -37,6 +37,7 @@ interface UseForm<T> {
     };
     setFieldValue: (path: string, value: any) => void;
     registerField: (path: string, initialValue: any) => void;
+    unregisterField: (path: string) => void;
 }
 export declare const useForm: <T extends Record<string, any>>(initialValues: T, validationRules?: ValidationRules<T>, config?: UseFormConfig) => UseForm<T>;
 export {};


### PR DESCRIPTION
## Summary
- implement `unregisterField` to remove dynamic fields
- expose new function from `useForm`
- document unregisterField usage

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6851b92f3188832e890c8f7dfd44b8c4