### PR TITLE
Add validateField method

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ A custom hook that provides utilities for managing form state.
 - `isValid`: `true` when the form has no validation errors.
 - `isSubmitting`: `true` while `handleSubmit` is running.
 - `validate`: Run validation and update the errors state. Returns a promise that resolves to `true` when the form is valid.
+- `validateField`: Validate a single field and update its error. Returns a promise that resolves to `true` when the form has no errors.
 - `dirtyFields`: Object tracking which fields have been modified.
 - `isDirty`: `true` when any field has changed.
 - `touchedFields`: Object tracking which fields have been blurred.
@@ -423,6 +424,7 @@ const {
   clearErrors,
   isSubmitting,
   validate,
+  validateField,
   watch,
   setFieldValue,
   registerField,

--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -297,6 +297,45 @@ const useForm = (initialValues, validationRules, config = {}) => {
     const validate = (0, react_1.useCallback)(() => __awaiter(void 0, void 0, void 0, function* () {
         return runValidation(values);
     }), [runValidation, values]);
+    const validateField = (0, react_1.useCallback)((pathString) => __awaiter(void 0, void 0, void 0, function* () {
+        const normalized = pathString
+            .replace(/\[(\w+)\]/g, ".$1")
+            .replace(/^\./, "");
+        const rule = validationRulesRef.current[normalized];
+        if (!rule) {
+            let nextErrors = {};
+            setErrors((prev) => {
+                const ne = Object.assign({}, prev);
+                delete ne[normalized];
+                nextErrors = ne;
+                return ne;
+            });
+            const valid = Object.keys(nextErrors).length === 0;
+            setIsValid(valid);
+            return valid;
+        }
+        const path = normalized
+            .split(".")
+            .filter(Boolean)
+            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const value = path.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
+        const error = yield rule(value, values);
+        let nextErrors = {};
+        setErrors((prev) => {
+            const ne = Object.assign({}, prev);
+            if (error) {
+                ne[normalized] = error;
+            }
+            else {
+                delete ne[normalized];
+            }
+            nextErrors = ne;
+            return ne;
+        });
+        const valid = Object.keys(nextErrors).length === 0;
+        setIsValid(valid);
+        return valid;
+    }), [values]);
     (0, react_1.useEffect)(() => {
         if (validateOnChange && validationRulesRef.current) {
             runValidation(values);
@@ -351,6 +390,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
         resetField,
         clearErrors,
         validate,
+        validateField,
         watch: watchCallback,
         setFieldValue,
         registerField,

--- a/dist/useForm.d.ts
+++ b/dist/useForm.d.ts
@@ -30,6 +30,7 @@ interface UseForm<T> {
     resetField: (path: string) => void;
     clearErrors: (path?: string) => void;
     validate: () => Promise<boolean>;
+    validateField: (path: string) => Promise<boolean>;
     watch: {
         (): T;
         <K extends keyof T>(key: K): T[K];


### PR DESCRIPTION
## Summary
- add `validateField` method to `useForm`
- document `validateField` in README
- rebuild dist

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851ba76ae8c832e8910b0a0c2f9096a