### PR TITLE
Fix validation path parsing

### DIFF
--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -22,6 +22,11 @@ var __rest = (this && this.__rest) || function (s, e) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useForm = void 0;
 const react_1 = require("react");
+const parsePath = (path) => path
+    .replace(/\[(\w+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean)
+    .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
 const useForm = (initialValues, validationRules, config = {}) => {
     const { validateOnChange = true, validateOnBlur = true } = config;
     const initialRef = (0, react_1.useRef)(initialValues);
@@ -77,11 +82,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
             newValue = value;
         }
         setValues((prevValues) => {
-            const path = name
-                .replace(/\[(\w+)\]/g, ".$1")
-                .split(".")
-                .filter(Boolean)
-                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const path = parsePath(name);
             const setNestedValue = (obj, keys, val) => {
                 var _a, _b;
                 if (!keys.length)
@@ -103,11 +104,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
     };
     const setFieldValue = (0, react_1.useCallback)((pathString, newValue) => {
         setValues((prevValues) => {
-            const path = pathString
-                .replace(/\[(\w+)\]/g, ".$1")
-                .split(".")
-                .filter(Boolean)
-                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const path = parsePath(pathString);
             const setNestedValue = (obj, keys, val) => {
                 var _a, _b;
                 if (!keys.length)
@@ -128,11 +125,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
         });
     }, []);
     const registerField = (0, react_1.useCallback)((pathString, initialValue) => {
-        const path = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const path = parsePath(pathString);
         const setNested = (obj, keys, val) => {
             var _a, _b;
             if (!keys.length)
@@ -160,10 +153,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
         }
     }, []);
     const handleBlur = (e) => {
-        const path = e.target.name
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean);
+        const path = parsePath(e.target.name);
         const topKey = path[0];
         setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
     };
@@ -187,11 +177,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
         setTouchedFields(newTouched);
     };
     const resetField = (pathString) => {
-        const path = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const path = parsePath(pathString);
         const topKey = path[0];
         const getNested = (obj, keys) => keys.reduce((acc, key) => acc === null || acc === void 0 ? void 0 : acc[key], obj);
         const initialVal = getNested(initialRef.current, path);
@@ -219,7 +205,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
             setErrors({});
             return;
         }
-        const normalized = pathString.replace(/\[(\w+)\]/g, ".$1").replace(/^\./, "");
+        const normalized = parsePath(pathString).join(".");
         setErrors((e) => {
             const ne = Object.assign({}, e);
             if (normalized in ne) {
@@ -283,7 +269,9 @@ const useForm = (initialValues, validationRules, config = {}) => {
         yield Promise.all(Object.keys(validationRulesRef.current).map((key) => __awaiter(void 0, void 0, void 0, function* () {
             const rule = validationRulesRef.current[key];
             if (rule) {
-                const error = yield rule(vals[key], vals);
+                const path = parsePath(key);
+                const value = path.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], vals);
+                const error = yield rule(value, vals);
                 if (error) {
                     newErrors[key] = error;
                 }

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -19,6 +19,11 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 import { useCallback, useState, useRef, useEffect } from "react";
+const parsePath = (path) => path
+    .replace(/\[(\w+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean)
+    .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
 export const useForm = (initialValues, validationRules, config = {}) => {
     const { validateOnChange = true, validateOnBlur = true } = config;
     const initialRef = useRef(initialValues);
@@ -74,11 +79,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             newValue = value;
         }
         setValues((prevValues) => {
-            const path = name
-                .replace(/\[(\w+)\]/g, ".$1")
-                .split(".")
-                .filter(Boolean)
-                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const path = parsePath(name);
             const setNestedValue = (obj, keys, val) => {
                 var _a, _b;
                 if (!keys.length)
@@ -100,11 +101,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
     };
     const setFieldValue = useCallback((pathString, newValue) => {
         setValues((prevValues) => {
-            const path = pathString
-                .replace(/\[(\w+)\]/g, ".$1")
-                .split(".")
-                .filter(Boolean)
-                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const path = parsePath(pathString);
             const setNestedValue = (obj, keys, val) => {
                 var _a, _b;
                 if (!keys.length)
@@ -125,11 +122,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         });
     }, []);
     const registerField = useCallback((pathString, initialValue) => {
-        const path = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const path = parsePath(pathString);
         const setNested = (obj, keys, val) => {
             var _a, _b;
             if (!keys.length)
@@ -157,10 +150,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         }
     }, []);
     const handleBlur = (e) => {
-        const path = e.target.name
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean);
+        const path = parsePath(e.target.name);
         const topKey = path[0];
         setTouchedFields((t) => (Object.assign(Object.assign({}, t), { [topKey]: true })));
     };
@@ -184,11 +174,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         setTouchedFields(newTouched);
     };
     const resetField = (pathString) => {
-        const path = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const path = parsePath(pathString);
         const topKey = path[0];
         const getNested = (obj, keys) => keys.reduce((acc, key) => acc === null || acc === void 0 ? void 0 : acc[key], obj);
         const initialVal = getNested(initialRef.current, path);
@@ -216,7 +202,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             setErrors({});
             return;
         }
-        const normalized = pathString.replace(/\[(\w+)\]/g, ".$1").replace(/^\./, "");
+        const normalized = parsePath(pathString).join(".");
         setErrors((e) => {
             const ne = Object.assign({}, e);
             if (normalized in ne) {
@@ -280,7 +266,9 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         yield Promise.all(Object.keys(validationRulesRef.current).map((key) => __awaiter(void 0, void 0, void 0, function* () {
             const rule = validationRulesRef.current[key];
             if (rule) {
-                const error = yield rule(vals[key], vals);
+                const path = parsePath(key);
+                const value = path.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], vals);
+                const error = yield rule(value, vals);
                 if (error) {
                     newErrors[key] = error;
                 }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -454,7 +454,9 @@ export const useForm = <T extends Record<string, any>>(
         Object.keys(validationRulesRef.current).map(async (key) => {
           const rule = validationRulesRef.current[key];
           if (rule) {
-            const error = await rule((vals as any)[key], vals);
+            const path = parsePath(key);
+            const value = path.reduce<any>((acc, seg) => acc?.[seg], vals);
+            const error = await rule(value, vals);
             if (error) {
               newErrors[key] = error;
             }


### PR DESCRIPTION
## Summary
- ensure nested path validation uses parsePath

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6851bedea608832e8106cd75c251860d