### PR TITLE
fix unregister dirty/touched

### DIFF
--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -246,14 +246,17 @@ const useForm = (initialValues, validationRules, config = {}) => {
         };
         const topKey = path[0];
         initialRef.current = removeNested(initialRef.current, path);
-        setValues((prev) => removeNested(prev, path));
-        setDirtyFields((d) => {
-            const _a = d, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
-            return rest;
-        });
-        setTouchedFields((t) => {
-            const _a = t, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
-            return rest;
+        setValues((prev) => {
+            const updated = removeNested(prev, path);
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialRef.current[topKey] })));
+            setTouchedFields((t) => {
+                if (updated[topKey] === undefined) {
+                    const _a = t, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
+                    return rest;
+                }
+                return t;
+            });
+            return updated;
         });
         clearErrors(pathString);
         if (pathString in validationRulesRef.current) {

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -243,14 +243,17 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         };
         const topKey = path[0];
         initialRef.current = removeNested(initialRef.current, path);
-        setValues((prev) => removeNested(prev, path));
-        setDirtyFields((d) => {
-            const _a = d, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
-            return rest;
-        });
-        setTouchedFields((t) => {
-            const _a = t, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
-            return rest;
+        setValues((prev) => {
+            const updated = removeNested(prev, path);
+            setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [topKey]: updated[topKey] !== initialRef.current[topKey] })));
+            setTouchedFields((t) => {
+                if (updated[topKey] === undefined) {
+                    const _a = t, _b = topKey, _omit = _a[_b], rest = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""]);
+                    return rest;
+                }
+                return t;
+            });
+            return updated;
         });
         clearErrors(pathString);
         if (pathString in validationRulesRef.current) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -423,15 +423,21 @@ export const useForm = <T extends Record<string, any>>(
 
     initialRef.current = removeNested(initialRef.current, path);
 
-    setValues((prev) => removeNested(prev, path));
-
-    setDirtyFields((d) => {
-      const { [topKey]: _omit, ...rest } = d;
-      return rest as DirtyFields<T>;
-    });
-    setTouchedFields((t) => {
-      const { [topKey]: _omit, ...rest } = t;
-      return rest as TouchedFields<T>;
+    setValues((prev) => {
+      const updated = removeNested(prev, path);
+      setDirtyFields((d) => ({
+        ...d,
+        [topKey]:
+          (updated as any)[topKey] !== (initialRef.current as any)[topKey],
+      }));
+      setTouchedFields((t) => {
+        if ((updated as any)[topKey] === undefined) {
+          const { [topKey]: _omit, ...rest } = t;
+          return rest as TouchedFields<T>;
+        }
+        return t;
+      });
+      return updated;
     });
 
     clearErrors(pathString);


### PR DESCRIPTION
## Summary
- improve `unregisterField` dirty and touched tracking

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851c8031f34832eb72e51bf4b56b88d