### PR TITLE
Fix parsePath usage

### DIFF
--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -219,11 +219,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
         });
     };
     const unregisterField = (0, react_1.useCallback)((pathString) => {
-        const path = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const path = parsePath(pathString);
         const removeNested = (obj, keys) => {
             if (!obj)
                 return obj;
@@ -289,9 +285,8 @@ const useForm = (initialValues, validationRules, config = {}) => {
         return runValidation(values);
     }), [runValidation, values]);
     const validateField = (0, react_1.useCallback)((pathString) => __awaiter(void 0, void 0, void 0, function* () {
-        const normalized = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .replace(/^\./, "");
+        const path = parsePath(pathString);
+        const normalized = path.join(".");
         const rule = validationRulesRef.current[normalized];
         if (!rule) {
             let nextErrors = {};
@@ -305,10 +300,6 @@ const useForm = (initialValues, validationRules, config = {}) => {
             setIsValid(valid);
             return valid;
         }
-        const path = normalized
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
         const value = path.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
         const error = yield rule(value, values);
         let nextErrors = {};
@@ -342,11 +333,7 @@ const useForm = (initialValues, validationRules, config = {}) => {
             return values;
         }
         if (typeof path === "string" && (path.includes(".") || path.includes("["))) {
-            const segments = path
-                .replace(/\[(\w+)\]/g, ".$1")
-                .split(".")
-                .filter(Boolean)
-                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const segments = parsePath(path);
             return segments.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
         }
         return values[path];

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -216,11 +216,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         });
     };
     const unregisterField = useCallback((pathString) => {
-        const path = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+        const path = parsePath(pathString);
         const removeNested = (obj, keys) => {
             if (!obj)
                 return obj;
@@ -286,9 +282,8 @@ export const useForm = (initialValues, validationRules, config = {}) => {
         return runValidation(values);
     }), [runValidation, values]);
     const validateField = useCallback((pathString) => __awaiter(void 0, void 0, void 0, function* () {
-        const normalized = pathString
-            .replace(/\[(\w+)\]/g, ".$1")
-            .replace(/^\./, "");
+        const path = parsePath(pathString);
+        const normalized = path.join(".");
         const rule = validationRulesRef.current[normalized];
         if (!rule) {
             let nextErrors = {};
@@ -302,10 +297,6 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             setIsValid(valid);
             return valid;
         }
-        const path = normalized
-            .split(".")
-            .filter(Boolean)
-            .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
         const value = path.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
         const error = yield rule(value, values);
         let nextErrors = {};
@@ -339,11 +330,7 @@ export const useForm = (initialValues, validationRules, config = {}) => {
             return values;
         }
         if (typeof path === "string" && (path.includes(".") || path.includes("["))) {
-            const segments = path
-                .replace(/\[(\w+)\]/g, ".$1")
-                .split(".")
-                .filter(Boolean)
-                .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+            const segments = parsePath(path);
             return segments.reduce((acc, seg) => acc === null || acc === void 0 ? void 0 : acc[seg], values);
         }
         return values[path];

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -390,11 +390,7 @@ export const useForm = <T extends Record<string, any>>(
   };
 
   const unregisterField = useCallback((pathString: string) => {
-    const path = pathString
-      .replace(/\[(\w+)\]/g, ".$1")
-      .split(".")
-      .filter(Boolean)
-      .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+    const path = parsePath(pathString);
 
     const removeNested = (obj: any, keys: (string | number)[]): any => {
       if (!obj) return obj;
@@ -484,9 +480,8 @@ export const useForm = <T extends Record<string, any>>(
 
   const validateField = useCallback(
     async (pathString: string): Promise<boolean> => {
-      const normalized = pathString
-        .replace(/\[(\w+)\]/g, ".$1")
-        .replace(/^\./, "");
+      const path = parsePath(pathString);
+      const normalized = path.join(".");
 
       const rule = validationRulesRef.current[normalized];
 
@@ -503,10 +498,6 @@ export const useForm = <T extends Record<string, any>>(
         return valid;
       }
 
-      const path = normalized
-        .split(".")
-        .filter(Boolean)
-        .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
       const value = path.reduce<any>((acc, seg) => acc?.[seg], values);
 
       const error = await rule(value, values);
@@ -550,11 +541,7 @@ export const useForm = <T extends Record<string, any>>(
     }
 
     if (typeof path === "string" && (path.includes(".") || path.includes("["))) {
-      const segments = path
-        .replace(/\[(\w+)\]/g, ".$1")
-        .split(".")
-        .filter(Boolean)
-        .map((seg) => (/^\d+$/.test(seg) ? parseInt(seg, 10) : seg));
+      const segments = parsePath(path);
       return segments.reduce<any>((acc, seg) => acc?.[seg], values);
     }
 


### PR DESCRIPTION
## Summary
- reuse `parsePath` inside `unregisterField`, `validateField`, and `watch`
- rebuild dist files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851c8c62bec832e8209e48e8162f4a4