### PR TITLE
Memoize setters

### DIFF
--- a/dist/cjs/useForm.js
+++ b/dist/cjs/useForm.js
@@ -47,16 +47,18 @@ const useForm = (initialValues, validationRules, config = {}) => {
     const [touchedFields, setTouchedFields] = (0, react_1.useState)(initialTouched);
     const isDirty = Object.keys(initialRef.current).some((k) => dirtyFields[k]);
     const isTouched = Object.keys(initialRef.current).some((k) => touchedFields[k]);
-    const setters = Object.keys(initialRef.current).reduce((acc, key) => {
-        acc[key] = (value) => {
-            setValues((prevValues) => {
-                const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
-                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialRef.current[key] })));
-                return newValues;
-            });
-        };
-        return acc;
-    }, {});
+    const setters = (0, react_1.useMemo)(() => {
+        return Object.keys(initialRef.current).reduce((acc, key) => {
+            acc[key] = (value) => {
+                setValues((prevValues) => {
+                    const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
+                    setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialRef.current[key] })));
+                    return newValues;
+                });
+            };
+            return acc;
+        }, {});
+    }, [initialRef.current]);
     const handleChange = (e) => {
         const { name, value, type } = e.target;
         if (type === "radio" &&

--- a/dist/esm/useForm.js
+++ b/dist/esm/useForm.js
@@ -18,7 +18,7 @@ var __rest = (this && this.__rest) || function (s, e) {
         }
     return t;
 };
-import { useCallback, useState, useRef, useEffect } from "react";
+import { useCallback, useState, useRef, useEffect, useMemo } from "react";
 const parsePath = (path) => path
     .replace(/\[(\w+)\]/g, ".$1")
     .split(".")
@@ -44,16 +44,18 @@ export const useForm = (initialValues, validationRules, config = {}) => {
     const [touchedFields, setTouchedFields] = useState(initialTouched);
     const isDirty = Object.keys(initialRef.current).some((k) => dirtyFields[k]);
     const isTouched = Object.keys(initialRef.current).some((k) => touchedFields[k]);
-    const setters = Object.keys(initialRef.current).reduce((acc, key) => {
-        acc[key] = (value) => {
-            setValues((prevValues) => {
-                const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
-                setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialRef.current[key] })));
-                return newValues;
-            });
-        };
-        return acc;
-    }, {});
+    const setters = useMemo(() => {
+        return Object.keys(initialRef.current).reduce((acc, key) => {
+            acc[key] = (value) => {
+                setValues((prevValues) => {
+                    const newValues = Object.assign(Object.assign({}, prevValues), { [key]: value });
+                    setDirtyFields((d) => (Object.assign(Object.assign({}, d), { [key]: newValues[key] !== initialRef.current[key] })));
+                    return newValues;
+                });
+            };
+            return acc;
+        }, {});
+    }, [initialRef.current]);
     const handleChange = (e) => {
         const { name, value, type } = e.target;
         if (type === "radio" &&

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef, useEffect } from "react";
+import { useCallback, useState, useRef, useEffect, useMemo } from "react";
 
 const parsePath = (path: string): (string | number)[] =>
   path
@@ -97,20 +97,22 @@ export const useForm = <T extends Record<string, any>>(
   const isDirty = Object.keys(initialRef.current).some((k) => dirtyFields[k]);
   const isTouched = Object.keys(initialRef.current).some((k) => touchedFields[k]);
 
-  const setters = Object.keys(initialRef.current).reduce((acc, key) => {
-    acc[key as keyof T] = (value: any) => {
-      setValues((prevValues) => {
-        const newValues = { ...prevValues, [key]: value };
-        setDirtyFields((d) => ({
-          ...d,
-          [key]:
-            newValues[key as keyof T] !== initialRef.current[key as keyof T],
-        }));
-        return newValues;
-      });
-    };
-    return acc;
-  }, {} as Setters<T>);
+  const setters = useMemo(() => {
+    return Object.keys(initialRef.current).reduce((acc, key) => {
+      acc[key as keyof T] = (value: any) => {
+        setValues((prevValues) => {
+          const newValues = { ...prevValues, [key]: value };
+          setDirtyFields((d) => ({
+            ...d,
+            [key]:
+              newValues[key as keyof T] !== initialRef.current[key as keyof T],
+          }));
+          return newValues;
+        });
+      };
+      return acc;
+    }, {} as Setters<T>);
+  }, [initialRef.current]);
 
   const handleChange = (
     e: React.ChangeEvent<


### PR DESCRIPTION
## Summary
- memoize `setters` to keep a stable reference

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851c9d6d5bc832e8f05dec95eef81f1