### PR TITLE
Add initial test setup

### DIFF
--- a/__tests__/useForm.test.tsx
+++ b/__tests__/useForm.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useForm } from '../src';
+
+describe('useForm', () => {
+  it('initializes with given values', () => {
+    const { result } = renderHook(() => useForm({ name: 'foo' }));
+    expect(result.current.values.name).toBe('foo');
+  });
+
+  it('updates values and tracks dirty/touched', () => {
+    const { result } = renderHook(() => useForm({ name: '' }));
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'name', value: 'bar', type: 'text' }
+      } as any);
+    });
+
+    expect(result.current.values.name).toBe('bar');
+    expect(result.current.dirtyFields.name).toBe(true);
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.touchedFields.name).toBe(true);
+    expect(result.current.isTouched).toBe(true);
+  });
+
+  it('runs validation rules', async () => {
+    const { result } = renderHook(() =>
+      useForm({ name: '' }, { name: (v) => (!v ? 'Required' : null) })
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.errors.name).toBe('Required');
+    expect(result.current.isValid).toBe(false);
+  });
+});
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "prepare": "npm run build"
   },
   "keywords": [
@@ -28,7 +28,13 @@
   "devDependencies": {
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "@types/jest": "^29.5.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/jest-dom": "^5.17.0"
   },
   "peerDependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add Jest configuration and setup script
- add basic tests for `useForm`
- update `test` script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516aea5020832eb37e29c6158fe8eb